### PR TITLE
DRAFT/WIP: refactor run_pabot to leverage testcasesplit

### DIFF
--- a/nac_test/pabot.py
+++ b/nac_test/pabot.py
@@ -53,7 +53,7 @@ def _run_pabot_with_args(
         args.extend(["--exclude", SPLIT_TAG])
 
     if verbose:
-        args.append("--verbose")
+        args.extend(["--verbose", "--loglevel", "TRACE"])
     if dry_run:
         args.append("--dryrun")
 
@@ -63,8 +63,6 @@ def _run_pabot_with_args(
             str(outdir),
             "--skiponfailure",
             "non-critical",
-            # "-x",
-            # "xunit.xml",
             str(path),
         ]
     )


### PR DESCRIPTION
This changes nac-test to run pabot twice:
1.  using `--testlevelsplit` to improve performance for very large test suites (ex: ACI l3out, epg, contracts) which have been refactored so that test cases can be executed independently from each other, and then 
2. regular pabot run

The two results are then merged (using `rebot`).

