### PR TITLE
expose exceptions to the user, use programmatic pabot entrypoint

### DIFF
--- a/nac_test/cli/main.py
+++ b/nac_test/cli/main.py
@@ -13,7 +13,10 @@ import typer
 import nac_test.pabot
 import nac_test.robot_writer
 
-app = typer.Typer(add_completion=False)
+# typer exceptions are BIG (albeit colorful), I feel for a program
+# with this complextiy logging everything is not required, hence disabling
+# them
+app = typer.Typer(add_completion=False, pretty_exceptions_enable=False)
 
 logger = logging.getLogger(__name__)
 
@@ -218,21 +221,18 @@ def main(
     else:
         ordering_file = None
 
-    try:
-        writer = nac_test.robot_writer.RobotWriter(
-            data, filters, tests, include, exclude
+    writer = nac_test.robot_writer.RobotWriter(data, filters, tests, include, exclude)
+    writer.write(templates, output, ordering_file=ordering_file)
+    if not render_only:
+        rc = nac_test.pabot.run_pabot(
+            output,
+            include,
+            exclude,
+            processes,
+            dry_run,
+            verbosity == VerbosityLevel.DEBUG,
+            ordering_file=ordering_file,
         )
-        writer.write(templates, output, ordering_file=ordering_file)
-        if not render_only:
-            nac_test.pabot.run_pabot(
-                output,
-                include,
-                exclude,
-                processes,
-                dry_run,
-                verbosity == VerbosityLevel.DEBUG,
-                ordering_file=ordering_file,
-            )
-    except Exception as e:
-        logger.error(f"Error during execution: {e}")
-        raise typer.Exit(code=1) from e
+    else:
+        rc = 0
+    raise typer.Exit(code=rc)

--- a/nac_test/pabot.py
+++ b/nac_test/pabot.py
@@ -16,7 +16,7 @@ def run_pabot(
     dry_run: bool = False,
     verbose: bool = False,
     ordering_file: Path | None = None,
-) -> None:
+) -> int:
     """Run pabot"""
     include = include or []
     exclude = exclude or []
@@ -48,4 +48,5 @@ def run_pabot(
         ]
     )
     logger.info("Running pabot with args: %s", " ".join(args))
-    pabot.pabot.main(args)
+    exit_code: int = pabot.pabot.main_program(args)
+    return exit_code


### PR DESCRIPTION
Change nac-test to use pabot's main_program() instead of main() to avoid pabot calling sys.exit(). This allows nac-test to control the exit behavior and return appropriate exit codes to the caller.

Also remove the big try/except block in main which swallows all the exceptions. As the typer exceptions are very large and it is difficult to really spot the issue, disable the pretty exceptions

Key changes:
- Update run_pabot() to call pabot.pabot.main_program() instead of main()
- Change run_pabot() return type from None to int
- Return exit code from pabot execution
- Update CLI main() to capture and use exit code
- Remove try/except wrapper in CLI main() - let exceptions propagate
- Disable typer pretty exceptions for cleaner error output

Benefits:
- Proper exit code handling (test failures, errors, etc.)
- No unexpected sys.exit() calls
- Cleaner error messages without verbose typer tracebacks
- Better integration with CI/CD systems

🤖 Generated with [Claude Code](https://claude.com/claude-code)