### PR TITLE
Add catc integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ CLAUDE.md
 
 # bandit security report, if generated
 bandit-security-report.json
+
+# workspace for local testing
+/workspace/

--- a/tests/integration/fixtures/data_pyats_qs/catc/data.yaml
+++ b/tests/integration/fixtures/data_pyats_qs/catc/data.yaml
@@ -1,0 +1,26 @@
+catalyst_center:
+  inventory:
+    devices:
+      # define three devices, one of them should be skipped. each device is counted as one test,
+      # so we can check by number of run tests if the skip worked as expected
+      - name: P3-E1
+        device_ip: 192.168.38.1
+        fqdn_name: P3-E1.cisco.eu
+        pid: C9300-24P
+        state: PROVISION
+        device_role: ACCESS
+        site: Global/MAX_AREA/MAX_BUILDING
+      - name: P3-E2
+        device_ip: 192.168.38.2
+        fqdn_name: P3-E2.cisco.eu
+        pid: C9300-24P
+        state: PROVISION
+        device_role: ACCESS
+        site: Global/MAX_AREA/MAX_BUILDING
+      - name: P3-E3
+        device_ip: 192.168.38.3
+        fqdn_name: P3-E3.cisco.eu
+        pid: C9300-24P
+        state: INIT
+        device_role: ACCESS
+        site: Global/MAX_AREA/MAX_BUILDING

--- a/tests/integration/fixtures/mock_api_config.yaml
+++ b/tests/integration/fixtures/mock_api_config.yaml
@@ -373,6 +373,37 @@ endpoints:
           deviceModel: "vedge-C8000V"
           personality: "vedge"
 
+  # Catalyst Center Authentication
+  - name: "Catalyst Center Authentication"
+    path_pattern: "/dna/system/api/v1/auth/token"
+    match_type: "exact"
+    method: "POST"
+    status_code: 200
+    response_data:
+      Token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NzU2ZDJhYmEyZTg1NzNkMGY1ZTNhNjgiLCJhdXRoU291cmNlIjoiaW50ZXJuYWwiLCJ0ZW5hbnROYW1lIjoiVE5UMCIsInJvbGVzIjpbIjY3NTZkMmFiYTJlODU3M2QwZjVlM2E1MiJdLCJ0ZW5hbnRJZCI6IjY3NTZkMmFiYTJlODU3M2QwZjVlM2E0OSIsImV4cCI6MTczNzM4MzYwOSwidXNlcm5hbWUiOiJhZG1pbiJ9.KvRo3_XZ8yK1vH2Gm9Lp7Qn6rE5dN4cO8wT1sY0mU3jF9xW2hA6kB8vP5lN7qI4oR3eD1fJ0gS2tU9nM6pL8iV4rB7cZ5kW1xN0yH3qG6mD9vF2sE8jT4nL7oP1wR5bA"
+
+  # Catalyst Center System Health
+  - name: "Catalyst Center System Health"
+    path_pattern: "/dna/intent/api/v1/diagnostics/system/health"
+    match_type: "contains"
+    method: "GET"
+    status_code: 200
+    response_data:
+      healthEvents:
+        - severity: 2
+          hostname: "kdna-dnac-03-vm.cisco.com"
+          instance: "kdna-dnac-03-vm.cisco.com:Internet URL Access"
+          subDomain: "Internet Access"
+          domain: "System"
+          description: "The following URLs are not reachable directly: http://validation.identrust.com/crl/hydrantidcao1.crl, http://commercial.ocsp.identrust.com."
+          state: "NotOk"
+          timestamp: "1765977209566"
+          status: "Warning"
+      hostname: "kdna-dnac-03-vm.cisco.com"
+      version: "1"
+      cimcaddress:
+        - "Cimc is not configured, please configure it from Settings->System Health Page."
+
   # SD-WAN Manager endpoints
   - name: "SD-WAN Manager Device Health"
     path_pattern: "/dataservice/health/devices"

--- a/tests/integration/fixtures/templates_pyats_qs/catc/tests/verify_dnac_catalyst_center_system_health_no_critical_events.py
+++ b/tests/integration/fixtures/templates_pyats_qs/catc/tests/verify_dnac_catalyst_center_system_health_no_critical_events.py
@@ -1,0 +1,294 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+"""
+[NRFU]: Verify Catalyst Center System Health - No Critical Events
+-----------------------------------------------------------------
+This job file verifies that Cisco Catalyst Center has no system health events
+in a Critical state, ensuring the controller is operating without major faults.
+"""
+
+import time
+from pyats import aetest
+
+import jmespath
+from nac_test_pyats_common.catc import CatalystCenterTestBase
+from nac_test.pyats_core.reporting.types import ResultStatus
+
+TITLE = "Verify Catalyst Center System Health Has No Critical Events"
+
+DESCRIPTION = """This test validates the overall health of Cisco Catalyst Center by checking
+for the absence of critical system health events. System health events reflect underlying
+controller platform issues, service faults, or infrastructure problems. Ensuring no events
+are in a Critical state is essential for stable controller operations, reliable network
+automation, and uninterrupted service delivery to managed devices."""
+
+SETUP = (
+    "* Access to an active Cisco Catalyst Center controller via HTTPS API is available.\n"
+    "* Authentication credentials for Catalyst Center are valid and configured.\n"
+    "* System diagnostics are enabled and Catalyst Center services are operational.\n"
+)
+
+PROCEDURE = (
+    "* Establish HTTPS connection to the Catalyst Center controller.\n"
+    "* Query the API endpoint: */dna/intent/api/v1/diagnostics/system/health?summary=true*.\n"
+    "* Parse the JSON response and extract the `healthEvents` array.\n"
+    "* For EACH health event:\n"
+    "    * Extract the `severity` and `state` attributes.\n"
+    "    * Verify that `severity` is NOT equal to 1 (Critical).\n"
+    "    * Verify that `state` is NOT equal to 'Critical'.\n"
+)
+
+PASS_FAIL_CRITERIA = (
+    "**This test passes when all of the following conditions are met:**\n"
+    "\n"
+    "* At least one system health event is returned by the Catalyst Center API.\n"
+    "* ALL system health events have `severity` not equal to 1 and `state` not equal to 'Critical'.\n"
+    "\n"
+    "**This test fails if any of the following criteria are met:**\n"
+    "\n"
+    "* No system health events are found in the API response.\n"
+    "* ANY event has `severity` equal to 1 (Critical).\n"
+    "* ANY event has `state` equal to 'Critical'.\n"
+    "* The API query fails or returns an error response.\n"
+)
+
+
+
+class VerifyCatCSystemHealthNoCriticalEvents(CatalystCenterTestBase):
+    """
+    [DNAC NRFU] Verify Catalyst Center System Health - No Critical Events
+
+    Verifies that there are no system health events with severity=1 (Critical)
+    or state="Critical" in Catalyst Center, indicating system is free of critical faults.
+    """
+
+    TEST_CONFIG = {
+        "resource_type": "Catalyst Center System Health Events",
+        "api_endpoint": "/dna/intent/api/v1/diagnostics/system/health?summary=true",
+        "expected_values": {
+            "severity": "not 1",
+            "state": "not Critical",
+        },
+        "log_fields": [
+            "check_type",
+            "verification_scope",
+            "total_health_events",
+            "healthy_events",
+            "critical_events",
+        ],
+    }
+
+    @aetest.test
+    def test_system_health_no_critical_events(self, steps):
+        """Entry point - delegates to base class orchestration."""
+        self.run_async_verification_test(steps)
+
+    def get_items_to_verify(self):
+        """
+        Returns a single context to trigger the global system health events check.
+        """
+        return [
+            {
+                "check_type": "system_health_no_critical_events",
+                "verification_scope": "all_health_events",
+            }
+        ]
+
+    async def verify_item(self, semaphore, client, context):
+        """
+        Verification: Discover ALL system health events and verify none are Critical.
+        Args:
+            semaphore: Asyncio semaphore for concurrency control.
+            client: HTTP client for making API calls.
+            context: Dictionary containing check_type and verification_scope.
+
+        Returns:
+            Dictionary containing verification result with status, reason, and metadata.
+        """
+        async with semaphore:
+            try:
+                url = self.TEST_CONFIG["api_endpoint"]
+
+                api_context = self.build_api_context(
+                    self.TEST_CONFIG['resource_type'],
+                    "Global System Health Check",
+                    check_type=context.get("check_type"),
+                    verification_scope=context.get("verification_scope"),
+                )
+
+                start_time = time.time()
+                response = await client.get(url, test_context=api_context)
+                api_duration = time.time() - start_time
+
+                context["api_context"] = api_context
+
+                if response.status_code != 200:
+                    context["display_context"] = "Catalyst Center System Health -> Events"
+
+                    return self.format_verification_result(
+                        status=ResultStatus.FAILED,
+                        context=context,
+                        reason=(
+                            f"API Error: Failed to query system health events (HTTP {response.status_code})\n\n"
+                            f"Failed to retrieve health events from endpoint: {self.TEST_CONFIG['api_endpoint']}\n\n"
+                            "Please verify:\n"
+                            "• The Catalyst Center controller is reachable and responding\n"
+                            "• Authentication credentials are valid\n"
+                            "• The API endpoint is accessible\n"
+                            "• Network connectivity to Catalyst Center is available"
+                        ),
+                        api_duration=api_duration,
+                    )
+
+                data = response.json()
+
+                health_events = jmespath.search("healthEvents[]", data) or []
+
+                if not health_events:
+                    context["display_context"] = "Catalyst Center System Health -> Events"
+                    return self.format_verification_result(
+                        status=ResultStatus.FAILED,
+                        context=context,
+                        reason=(
+                            "No system health events found in Catalyst Center response.\n\n"
+                            "This indicates that either:\n"
+                            "• No health events have been generated\n"
+                            "• The API query returned no results\n"
+                            "• System diagnostics may not be enabled\n\n"
+                            "Please verify:\n"
+                            "• Catalyst Center system diagnostics are operational\n"
+                            "• API endpoint is returning valid data"
+                        ),
+                        api_duration=api_duration,
+                    )
+
+                expected_values = self.TEST_CONFIG["expected_values"]
+                attributes_to_verify = expected_values.keys()
+
+                all_events_healthy = True
+                validation_results = []
+                failures = []
+                healthy_count = 0
+                critical_count = 0
+
+                for idx, event in enumerate(health_events):
+                    hostname = jmespath.search("hostname", event) or "Not Found"
+                    description = jmespath.search("description", event) or "No Description"
+                    severity = jmespath.search("severity", event) or "Not Found"
+                    state = jmespath.search("state", event) or "Not Found"
+                    timestamp = jmespath.search("timestamp", event) or "Not Found"
+                    status = jmespath.search("status", event) or "Not Found"
+                    instance = jmespath.search("instance", event) or "Not Found"
+                    subDomain = jmespath.search("subDomain", event) or "Not Found"
+                    domain = jmespath.search("domain", event) or "Not Found"
+
+                    event_failures = []
+
+                    # Check severity
+                    if str(severity) == "1":
+                        event_failures.append(
+                            f"  • severity: Expected not '1', got '{severity}'"
+                        )
+                    # Check state
+                    if str(state) == "Critical":
+                        event_failures.append(
+                            f"  • state: Expected not 'Critical', got '{state}'"
+                        )
+
+                    if event_failures:
+                        all_events_healthy = False
+                        critical_count += 1
+                        failure_detail = (
+                            f"**Event #{idx+1} ({instance})**\n"
+                            f"  Hostname: {hostname}\n"
+                            f"  Domain/SubDomain: {domain}/{subDomain}\n"
+                            f"  Description: {description}\n"
+                            f"  Severity: {severity}\n"
+                            f"  State: {state}\n"
+                            f"  Status: {status}\n"
+                            f"  Timestamp: {timestamp}\n"
+                            f"  Failures:\n" + "\n".join(event_failures)
+                        )
+                        failures.append(failure_detail)
+                        validation_results.append(
+                            f"❌ Event '{instance}' on {hostname} - severity={severity}, state={state}, status={status}"
+                        )
+                    else:
+                        healthy_count += 1
+                        validation_results.append(
+                            f"✅ Event '{instance}' on {hostname} - severity={severity}, state={state}, status={status}"
+                        )
+
+                context["total_health_events"] = len(health_events)
+                context["healthy_events"] = healthy_count
+                context["critical_events"] = critical_count
+
+                result_summary = "\n".join(validation_results)
+
+                context["display_context"] = "Catalyst Center System Health -> Events"
+
+                if all_events_healthy:
+                    return self.format_verification_result(
+                        status=ResultStatus.PASSED,
+                        context=context,
+                        reason=(
+                            f"**Catalyst Center System Health Events Check PASSED**\n\n"
+                            f"All {len(health_events)} system health events have severity ≠ 1 (Critical) and state ≠ 'Critical'.\n\n"
+                            f"**Validation Results:**\n"
+                            f"{result_summary}\n\n"
+                            f"**System Health Events Status:**\n"
+                            f"• Total discovered health events: {len(health_events)}\n"
+                            f"• Events without Critical severity/state: {healthy_count}\n"
+                            f"• All events healthy (no Critical): Yes\n"
+                            f"• API query duration: {api_duration:.2f}s"
+                        ),
+                        api_duration=api_duration,
+                    )
+                else:
+                    return self.format_verification_result(
+                        status=ResultStatus.FAILED,
+                        context=context,
+                        reason=(
+                            f"**Catalyst Center System Health Events Check FAILED**\n\n"
+                            f"One or more system health events have severity=1 (Critical) or state='Critical'.\n\n"
+                            f"**Validation Results:**\n"
+                            f"{result_summary}\n\n"
+                            f"**Detailed Failures:**\n"
+                            f"{chr(10).join(failures)}\n\n"
+                            f"**System Health Events Status:**\n"
+                            f"• Total discovered health events: {len(health_events)}\n"
+                            f"• Events without Critical severity/state: {healthy_count}\n"
+                            f"• Events with Critical severity/state: {critical_count}\n\n"
+                            f"**Please verify:**\n"
+                            f"• Review system health events in Catalyst Center\n"
+                            f"• Investigate any events with severity=1 or state='Critical'\n"
+                            f"• Address underlying system issues or faults\n"
+                            f"• Ensure Catalyst Center services are healthy\n"
+                            f"• API query duration: {api_duration:.2f}s"
+                        ),
+                        api_duration=api_duration,
+                    )
+
+            except Exception as e:
+                error_msg = f"Exception during system health events check: {str(e)}"
+                self.logger.error(
+                    f"Exception for Catalyst Center System Health Events Check: {error_msg}",
+                    exc_info=True,
+                )
+
+                context["display_context"] = "Catalyst Center System Health -> Events"
+
+                reason = (
+                    f"PyATS Framework Exception: {error_msg}\n\n"
+                    f"This is a PyATS code issue, not an issue with your data model, "
+                    f"Catalyst Center configuration, or your network.\n\n"
+                    f"Please contact Cisco TAC for support with this error."
+                )
+
+                return self.format_verification_result(
+                    status=ResultStatus.FAILED,
+                    context=context,
+                    reason=reason,
+                    api_duration=0,
+                )

--- a/tests/integration/fixtures/templates_pyats_qs/catc/tests/verify_iosxe_no_critical_errors_in_system_logs.py
+++ b/tests/integration/fixtures/templates_pyats_qs/catc/tests/verify_iosxe_no_critical_errors_in_system_logs.py
@@ -1,0 +1,408 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+"""
+[NRFU]: Verify No Critical Errors in System Logs
+------------------------------------------------
+This job verifies that the IOS-XE device system log contains no critical errors,
+hardware failures, configuration rollbacks, AAA failures, or software exceptions.
+"""
+
+import time
+import re
+from pyats import aetest
+
+import jmespath
+from nac_test_pyats_common.iosxe import IOSXETestBase
+from nac_test.pyats_core.reporting.types import ResultStatus
+
+TITLE = "Verify No Critical Errors in System Logs"
+
+DESCRIPTION = """This test checks the system log on an IOS-XE device for the presence of any
+critical errors, hardware failures, configuration rollbacks, AAA failures, software exceptions,
+or recurring error-level messages. System logs are essential for identifying operational issues,
+hardware faults, authentication problems, or abnormal software behavior. Ensuring that the
+system log is free of high-severity or persistent errors is vital for network reliability,
+device stability, and early detection of infrastructure issues."""
+
+SETUP = (
+    "* SSH access to the target IOS-XE network device is available.\n"
+    "* Authentication credentials for the device are valid and configured.\n"
+    "* System logging is enabled and log buffer contains current entries.\n"
+    "* The device is operational and reachable via the management network.\n"
+)
+
+PROCEDURE = (
+    "* Establish SSH connection to the IOS-XE network device.\n"
+    "* Execute the CLI command: *show logging* to retrieve the device system log buffer.\n"
+    "* Parse the command output using the Genie parser to obtain structured log entries.\n"
+    "* For EACH log entry discovered in the parsed output:\n"
+    "    * Extract the log message severity from the syslog header (e.g., %FAC-SEV-CODE).\n"
+    "    * Check for the following:\n"
+    "        * Any log entry with severity 0 (Emergency), 1 (Alert), or 2 (Critical).\n"
+    "        * Any message text indicating hardware failures (e.g., power, fan, module).\n"
+    "        * Any message text indicating configuration rollback or abort.\n"
+    "        * Any message text indicating AAA (authentication/authorization/accounting) failure.\n"
+    "        * Any message text indicating a software exception or crash.\n"
+    "        * Recurring (persistent) severity 3 (Error) messages by counting repeated signatures.\n"
+    "* Summarize results, reporting any discovered critical or recurring issues.\n"
+)
+
+PASS_FAIL_CRITERIA = (
+    "**This test passes when all of the following conditions are met:**\n"
+    "\n"
+    "* At least one log entry is discovered in the system log buffer.\n"
+    "* No log entries have severity 0, 1, or 2 (Emergency, Alert, Critical).\n"
+    "* No log entries indicate hardware failures (e.g., FAN, PSU, module, overheat, sensor).\n"
+    "* No log entries indicate configuration rollback or abort events.\n"
+    "* No log entries indicate AAA (authentication/authorization/accounting) failures.\n"
+    "* No log entries indicate software exceptions or crashes.\n"
+    "* No recurring (persistent) severity 3 (Error) messages with the same signature.\n"
+    "\n"
+    "**This test fails if any of the following criteria are met:**\n"
+    "\n"
+    "* The system log buffer is empty or cannot be parsed.\n"
+    "* One or more log entries have severity 0, 1, or 2 (Emergency, Alert, Critical).\n"
+    "* Any log entry indicates hardware failure, configuration rollback, AAA failure, or software exception.\n"
+    "* One or more recurring severity 3 (Error) messages are found with the same signature.\n"
+    "* The CLI command fails to execute or returns an error.\n"
+    "* The Genie parser fails to parse the command output.\n"
+)
+
+
+
+class VerifyNoCriticalErrorsInSystemLogs(IOSXETestBase):
+    """
+    [IOS-XE] Verify No Critical Errors in System Logs
+
+    Checks all log entries in 'logs' (from Genie-parsed 'show logging') for:
+    - No critical syslog messages (severity 0, 1, or 2)
+    - No log messages indicating hardware failures, configuration rollbacks, AAA failures, or software exceptions
+    - No persistent or recurring issues at severity 3 (Error)
+    """
+
+    TEST_CONFIG = {
+        "resource_type": "System Log",
+        "api_endpoint": "show logging",
+        "expected_values": {
+            # There are no direct keys for severity/message in Genie output;
+            # We must parse 'logs' entries for syslog severity and error patterns.
+            "logs": "no_critical_errors",  # Special marker; actual logic is in verify_item
+        },
+        "log_fields": [
+            "check_type",
+            "verification_scope",
+            "total_logs",
+            "critical_logs",
+            "hardware_error_logs",
+            "config_rollback_logs",
+            "aaa_failure_logs",
+            "sw_exception_logs",
+            "persistent_error_logs",
+        ],
+    }
+
+    @aetest.test
+    def test_system_log_health(self, steps):
+        """Entry point - delegates to base class orchestration."""
+        self.run_async_verification_test(steps)
+
+    def get_items_to_verify(self):
+        """
+        Returns a single context to trigger the log buffer check.
+        """
+        return [
+            {
+                "check_type": "system_log_health",
+                "verification_scope": "all_syslog_entries",
+            }
+        ]
+
+    async def verify_item(self, semaphore, client, context):
+        """
+        Verification: Check all logs in Genie-parsed 'show logging' output for:
+        - No severity 0, 1, 2 log entries
+        - No messages indicating hardware failure, config rollback, AAA failure, software exception
+        - No persistent/recurrent severity 3 errors
+        """
+        async with semaphore:
+            try:
+                command = self.TEST_CONFIG["api_endpoint"]
+
+                api_context = self.build_api_context(
+                    self.TEST_CONFIG["resource_type"],
+                    "All System Logs",
+                    check_type=context.get("check_type"),
+                    verification_scope=context.get("verification_scope"),
+                )
+
+                start_time = time.time()
+
+                with self.test_context(api_context):
+                    output = await self.execute_command(command)
+                command_duration = time.time() - start_time
+
+                parse_start = time.time()
+                parsed_output = self.parse_output(command, output=output)
+                parse_duration = time.time() - parse_start
+
+                api_duration = command_duration + parse_duration
+
+                context["api_context"] = api_context
+
+                if parsed_output is None:
+                    context['display_context'] = "System Log -> State"
+                    return self.format_verification_result(
+                        status=ResultStatus.FAILED,
+                        context=context,
+                        reason=f"Parsed output is None for command: {command}",
+                        api_duration=api_duration,
+                    )
+
+                # Extract all logs (list of log lines)
+                log_lines = jmespath.search("logs[]", parsed_output) or []
+                total_logs = len(log_lines)
+                context["total_logs"] = total_logs
+
+                if not log_lines:
+                    context['display_context'] = "System Log -> State"
+                    return self.format_verification_result(
+                        status=ResultStatus.FAILED,
+                        context=context,
+                        reason=(
+                            "No log entries found in Genie-parsed 'show logging' output.\n\n"
+                            "This indicates that either:\n"
+                            "• The device logging buffer is empty\n"
+                            "• The parser failed to extract logs\n"
+                            "• There are no recent log messages\n\n"
+                            "Please verify device logging configuration and try again."
+                        ),
+                        api_duration=api_duration,
+                    )
+
+                # Severity mapping: %FAC-SEV-CODE
+                # 0 = Emergency, 1 = Alert, 2 = Critical, 3 = Error, 4 = Warning, 5 = Notification, 6 = Informational, 7 = Debug
+                severity_regex = re.compile(r"%[\w\-]+-(\d)-[\w_]+:")
+
+                # Patterns for hardware failure, config rollback, AAA failure, software exceptions
+                hw_pattern = re.compile(
+                    r"(FAN|PSU|PWR|SUPERVISOR|HARDWARE|OVERHEAT|TEMP|FRU|SENSOR|ASIC|linecard|module|hardware failure|power failure|voltage|fan fail|system overheat)",
+                    re.IGNORECASE,
+                )
+                config_rb_pattern = re.compile(
+                    r"(rollback|config(uration)?\s+rollback|rollback completed|rollback failed|rollback triggered|config replace|config failure|config error|config abort)",
+                    re.IGNORECASE,
+                )
+                aaa_fail_pattern = re.compile(
+                    r"(AAA|authentication|authorization|accounting)\s+(fail|failure|error|denied|unsuccessful|unsuccessfully|rejected|invalid)|login failed|user authentication failed",
+                    re.IGNORECASE,
+                )
+                sw_exc_pattern = re.compile(
+                    r"(exception|crash|software error|fatal error|stack trace|core dumped|segmentation fault|SW crash|SW exception)",
+                    re.IGNORECASE,
+                )
+
+                # For persistent/recurrent errors at severity 3, collect count by message signature
+                error_sig_counter = {}
+
+                critical_logs = []
+                hardware_error_logs = []
+                config_rollback_logs = []
+                aaa_failure_logs = []
+                sw_exception_logs = []
+                error_logs = []
+
+                validation_results = []
+                failures = []
+
+                for log in log_lines:
+                    # Try to extract severity
+                    sev_match = severity_regex.search(log)
+                    if sev_match:
+                        severity = int(sev_match.group(1))
+                    else:
+                        # If no severity, treat as informational (best effort, usually banner lines or incomplete)
+                        severity = 6
+
+                    # Check for severity 0/1/2 (emerg/alert/critical)
+                    if severity in (0, 1, 2):
+                        critical_logs.append(log)
+                        validation_results.append(
+                            f"❌ [Severity {severity}] {log.strip()}"
+                        )
+
+                    # Check for hardware failures (any severity)
+                    if hw_pattern.search(log):
+                        hardware_error_logs.append(log)
+
+                    # Check for config rollback (any severity)
+                    if config_rb_pattern.search(log):
+                        config_rollback_logs.append(log)
+
+                    # Check for AAA failures (any severity)
+                    if aaa_fail_pattern.search(log):
+                        aaa_failure_logs.append(log)
+
+                    # Check for SW exceptions (any severity)
+                    if sw_exc_pattern.search(log):
+                        sw_exception_logs.append(log)
+
+                    # Track severity 3 (Error) for persistent errors
+                    if severity == 3:
+                        # Build an error signature (facility, code, message w/o timestamp)
+                        err_sig_match = re.search(r"%([\w\-]+)-3-([\w_]+):\s*(.+)", log)
+                        if err_sig_match:
+                            sig = f"{err_sig_match.group(1)}-{err_sig_match.group(2)}: {err_sig_match.group(3).strip()}"
+                            # Remove any interface, address, or time-variant info to generalize signature
+                            sig = re.sub(r"(\d+\.\d+\.\d+\.\d+)|(\bGi\d+/\d+/\d+\b)|(\bTe\d+/\d+/\d+\b)|(\bEth\d+/\d+/\d+\b)", "<REDACTED>", sig)
+                        else:
+                            sig = log
+                        error_sig_counter[sig] = error_sig_counter.get(sig, 0) + 1
+                        error_logs.append(log)
+
+                # Persistent error = same error signature seen more than once
+                persistent_error_logs = [
+                    sig for sig, count in error_sig_counter.items() if count > 1
+                ]
+
+                context["critical_logs"] = len(critical_logs)
+                context["hardware_error_logs"] = len(hardware_error_logs)
+                context["config_rollback_logs"] = len(config_rollback_logs)
+                context["aaa_failure_logs"] = len(aaa_failure_logs)
+                context["sw_exception_logs"] = len(sw_exception_logs)
+                context["persistent_error_logs"] = len(persistent_error_logs)
+
+                # Build failures for all categories found
+                if critical_logs:
+                    failures.append(
+                        f"**Critical severity logs (0/1/2) found ({len(critical_logs)}):**\n"
+                        + "\n".join(f"  • {l}" for l in critical_logs[:5])
+                        + ("\n  ... (additional omitted)" if len(critical_logs) > 5 else "")
+                    )
+                if hardware_error_logs:
+                    failures.append(
+                        f"**Hardware failure logs found ({len(hardware_error_logs)}):**\n"
+                        + "\n".join(f"  • {l}" for l in hardware_error_logs[:5])
+                        + ("\n  ... (additional omitted)" if len(hardware_error_logs) > 5 else "")
+                    )
+                if config_rollback_logs:
+                    failures.append(
+                        f"**Configuration rollback logs found ({len(config_rollback_logs)}):**\n"
+                        + "\n".join(f"  • {l}" for l in config_rollback_logs[:5])
+                        + ("\n  ... (additional omitted)" if len(config_rollback_logs) > 5 else "")
+                    )
+                if aaa_failure_logs:
+                    failures.append(
+                        f"**AAA failure logs found ({len(aaa_failure_logs)}):**\n"
+                        + "\n".join(f"  • {l}" for l in aaa_failure_logs[:5])
+                        + ("\n  ... (additional omitted)" if len(aaa_failure_logs) > 5 else "")
+                    )
+                if sw_exception_logs:
+                    failures.append(
+                        f"**Software exception logs found ({len(sw_exception_logs)}):**\n"
+                        + "\n".join(f"  • {l}" for l in sw_exception_logs[:5])
+                        + ("\n  ... (additional omitted)" if len(sw_exception_logs) > 5 else "")
+                    )
+                if persistent_error_logs:
+                    persistent_details = [
+                        f"  • '{sig}' occurred {error_sig_counter[sig]} times"
+                        for sig in persistent_error_logs
+                    ]
+                    failures.append(
+                        f"**Persistent (recurring) severity 3 errors found ({len(persistent_error_logs)}):**\n"
+                        + "\n".join(persistent_details)
+                    )
+
+                # Build summary
+                result_summary = (
+                    f"• Total log entries checked: {total_logs}\n"
+                    f"• Critical severity (0/1/2): {len(critical_logs)}\n"
+                    f"• Hardware error logs: {len(hardware_error_logs)}\n"
+                    f"• Config rollback logs: {len(config_rollback_logs)}\n"
+                    f"• AAA failure logs: {len(aaa_failure_logs)}\n"
+                    f"• SW exception logs: {len(sw_exception_logs)}\n"
+                    f"• Persistent severity 3 errors: {len(persistent_error_logs)}"
+                )
+
+                context['display_context'] = "System Log -> State"
+
+                if (
+                    not critical_logs
+                    and not hardware_error_logs
+                    and not config_rollback_logs
+                    and not aaa_failure_logs
+                    and not sw_exception_logs
+                    and not persistent_error_logs
+                ):
+                    # PASSED
+                    return self.format_verification_result(
+                        status=ResultStatus.PASSED,
+                        context=context,
+                        reason=(
+                            f"**System Log Check PASSED**\n\n"
+                            f"All {total_logs} system log entries are free of critical errors.\n\n"
+                            f"**Pass Conditions:**\n"
+                            f"• No log entries with severity 0, 1, or 2 (Emergency/Alert/Critical)\n"
+                            f"• No log entries indicating hardware failures, configuration rollbacks, AAA failures, or software exceptions\n"
+                            f"• No persistent or recurring severity 3 (Error) messages\n\n"
+                            f"**Validation Results:**\n"
+                            f"{result_summary}\n\n"
+                            f"**System Log Status:**\n"
+                            f"• Total logs checked: {total_logs}\n"
+                            f"• All critical error checks passed: Yes\n"
+                            f"• Command execution duration: {api_duration:.2f}s"
+                        ),
+                        api_duration=api_duration,
+                    )
+                else:
+                    # FAILED
+                    return self.format_verification_result(
+                        status=ResultStatus.FAILED,
+                        context=context,
+                        reason=(
+                            f"**System Log Check FAILED**\n\n"
+                            f"One or more system log entries indicate critical errors or issues.\n\n"
+                            f"**Validation Results:**\n"
+                            f"{result_summary}\n\n"
+                            f"**Detailed Failures:**\n"
+                            f"{chr(10).join(failures)}\n\n"
+                            f"**System Log Status:**\n"
+                            f"• Total logs checked: {total_logs}\n"
+                            f"• Critical severity logs: {len(critical_logs)}\n"
+                            f"• Hardware error logs: {len(hardware_error_logs)}\n"
+                            f"• Config rollback logs: {len(config_rollback_logs)}\n"
+                            f"• AAA failure logs: {len(aaa_failure_logs)}\n"
+                            f"• SW exception logs: {len(sw_exception_logs)}\n"
+                            f"• Persistent severity 3 errors: {len(persistent_error_logs)}\n\n"
+                            f"**Please verify:**\n"
+                            f"• Hardware status and replace failed components\n"
+                            f"• Configuration history for rollbacks or aborts\n"
+                            f"• AAA server/device user authentication configuration\n"
+                            f"• Software version and known bugs (if exceptions found)\n"
+                            f"• Recurring error messages for root cause analysis\n"
+                            f"• Device clock and log buffer size (for completeness)\n"
+                            f"• See sample log entries above for details\n"
+                            f"• Command execution duration: {api_duration:.2f}s"
+                        ),
+                        api_duration=api_duration,
+                    )
+
+            except Exception as e:
+                error_msg = f"Exception during system log health check: {str(e)}"
+                self.logger.error(
+                    f"Exception for System Log Health Check: {error_msg}",
+                    exc_info=True,
+                )
+                context["display_context"] = "System Log -> State"
+                reason = (
+                    f"PyATS Framework Exception: {error_msg}\n\n"
+                    f"This is a PyATS code issue, not an issue with your data model, "
+                    f"Catalyst Center configuration, or your network devices.\n\n"
+                    f"Please contact Cisco TAC for support with this error."
+                )
+                return self.format_verification_result(
+                    status=ResultStatus.FAILED,
+                    context=context,
+                    reason=reason,
+                    api_duration=0,
+                )

--- a/tests/integration/mocks/mock_data/iosxe/iosxe_mock_data.yaml
+++ b/tests/integration/mocks/mock_data/iosxe/iosxe_mock_data.yaml
@@ -21,7 +21,45 @@ enable_isr:
 
       --------------------------------------------------------------------------------
       Auto abort timer: inactive
-      --------------------------------------------------------------------------------
+        --------------------------------------------------------------------------------
+    "show logging": |
+      Syslog logging: enabled (0 messages dropped, 2 messages rate-limited, 0 flushes, 0 overruns, xml disabled, filtering disabled)
+
+      No Active Message Discriminator.
+
+
+
+      No Inactive Message Discriminator.
+
+
+        Console logging: disabled
+        Monitor logging: level debugging, 0 messages logged, xml disabled,
+                          filtering disabled
+        Buffer logging:  level debugging, 6038 messages logged, xml disabled,
+                        filtering disabled
+        Exception Logging: size (4096 bytes)
+        Count and timestamp logging messages: disabled
+        File logging: disabled
+        Persistent logging: disabled
+
+      No active filter modules.
+
+        Trap logging: level informational, 6036 message lines logged
+            Logging Source-Interface:       VRF Name:
+        TLS Profiles: 
+
+      Log Buffer (102400 bytes):
+      ceived (*, 239.255.255.254) Join from 192.168.34.67 for invalid RP 192.168.34.64
+      005285: *Jan 20 01:29:08.097: %PIM-6-INVALID_RP_JOIN: Received (*, 224.0.1.40) Join from 192.168.34.69 for invalid RP 192.168.34.64
+      005286: *Jan 20 01:30:14.538: %PIM-6-INVALID_RP_JOIN: Received (*, 239.255.255.250) Join from 192.168.34.67 for invalid RP 192.168.34.64
+      005287: *Jan 20 01:31:18.638: %PIM-6-INVALID_RP_JOIN: Received (*, 224.0.1.40) Join from 192.168.34.67 for invalid RP 192.168.34.64
+      005288: *Jan 20 01:32:28.638: %PIM-6-INVALID_RP_JOIN: Received (*, 239.255.255.254) Join from 192.168.34.67 for invalid RP 192.168.34.64
+      005289: *Jan 20 01:34:05.892: %PIM-6-INVALID_RP_JOIN: Received (*, 224.0.1.40) Join from 192.168.34.69 for invalid RP 192.168.34.64
+      005290: *Jan 20 01:35:10.438: %PIM-6-INVALID_RP_JOIN: Received (*, 239.255.255.250) Join from 192.168.34.67 for invalid RP 192.168.34.64
+      005291: *Jan 20 01:36:12.738: %PIM-6-INVALID_RP_JOIN: Received (*, 224.0.1.40) Join from 192.168.34.67 for invalid RP 192.168.34.64
+      005292: *Jan 20 01:37:24.038: %PIM-6-INVALID_RP_JOIN: Received (*, 239.255.255.254) Join from 192.168.34.67 for invalid RP 192.168.34.64
+      005293: *Jan 20 01:39:01.186: %PIM-6-INVALID_RP_JOIN: Received (*, 224.0.1.40) Join from 192.168.34.69 for invalid RP 192.168.34.64
+      005294: *Jan 20 01:40:03.538: %PIM-6-INVALID_RP_JOIN: Received (*, 239.255.255.250) Join from 192.168.34.67 for invalid RP 192.168.34.64
 
 config:
   commands:

--- a/tests/integration/test_integration_pyats.py
+++ b/tests/integration/test_integration_pyats.py
@@ -84,20 +84,24 @@ def _validate_pyats_results(output_dir: str | Path, passed: int, failed: int) ->
         total_failed += summary["failed"]
 
     # Verify passed and failed counts
-    assert total_passed == passed, f"passed: expected={passed}, actual={total_passed}"
-    assert total_failed == failed, f"failed: expected={failed}, actual={total_failed}"
+    assert (total_passed, total_failed) == (passed, failed), (
+        f"Test results do not match expected values: "
+        f"expected passed={passed}, failed={failed}; "
+        f"actual passed={total_passed}, failed={total_failed}"
+    )
 
 
 @pytest.mark.parametrize(
-    "arch,passed,failed,expected_rc",
+    "arch,env_prefix,passed,failed,expected_rc",
     [
-        ("aci", 1, 0, 0),
+        ("aci", "ACI", 1, 0, 0),
     ],
 )
 def test_nac_test_pyats_quicksilver_api_only(
     mock_api_server: MockAPIServer,
     tmpdir: str,
     arch: str,
+    env_prefix: str,
     passed: int,
     failed: int,
     expected_rc: int,
@@ -108,9 +112,9 @@ def test_nac_test_pyats_quicksilver_api_only(
     for API-only architectures (i.e. no d2d tests)
     """
     runner = CliRunner()
-    monkeypatch.setenv(f"{arch.upper()}_URL", mock_api_server.url)
-    monkeypatch.setenv(f"{arch.upper()}_USERNAME", "does not matter")
-    monkeypatch.setenv(f"{arch.upper()}_PASSWORD", "does not matter")
+    monkeypatch.setenv(f"{env_prefix}_URL", mock_api_server.url)
+    monkeypatch.setenv(f"{env_prefix}_USERNAME", "does not matter")
+    monkeypatch.setenv(f"{env_prefix}_PASSWORD", "does not matter")
 
     data_path = f"tests/integration/fixtures/data_pyats_qs/{arch}"
     templates_path = f"tests/integration/fixtures/templates_pyats_qs/{arch}/"
@@ -137,15 +141,17 @@ def test_nac_test_pyats_quicksilver_api_only(
 
 
 @pytest.mark.parametrize(
-    "arch,passed,failed,expected_rc",
+    "arch,env_prefix,passed,failed,expected_rc",
     [
-        ("sdwan", 3, 0, 0),
+        ("sdwan", "SDWAN", 3, 0, 0),
+        ("catc", "CC", 3, 0, 0),
     ],
 )
 def test_nac_test_pyats_quicksilver_api_d2d(
     mock_api_server: MockAPIServer,
     tmpdir: str,
     arch: str,
+    env_prefix: str,
     passed: int,
     failed: int,
     expected_rc: int,
@@ -182,9 +188,9 @@ def test_nac_test_pyats_quicksilver_api_d2d(
         runner = CliRunner()
 
         # Set up environment for both API (SDWAN_*) and D2D (IOSXE_*) tests
-        monkeypatch.setenv(f"{arch.upper()}_URL", mock_api_server.url)
-        monkeypatch.setenv(f"{arch.upper()}_USERNAME", "does not matter")
-        monkeypatch.setenv(f"{arch.upper()}_PASSWORD", "does not matter")
+        monkeypatch.setenv(f"{env_prefix}_URL", mock_api_server.url)
+        monkeypatch.setenv(f"{env_prefix}_USERNAME", "does not matter")
+        monkeypatch.setenv(f"{env_prefix}_PASSWORD", "does not matter")
         monkeypatch.setenv("IOSXE_USERNAME", "admin")
         monkeypatch.setenv("IOSXE_PASSWORD", "admin")
 


### PR DESCRIPTION
- Add CatC test fixtures for system health and device log verification
- Add test data model with 3 devices (2 PROVISION, 1 INIT state which will be ignored)
- Add mock API configuration for CatC endpoints
- Add IOS-XE mock data for device-to-device testing
- Update integration test suite with CatC test case
- Update .gitignore to exclude test artifacts
- Update conftest.py with mock server configuration
- clear already set controller env vars before starting tests

Test cases:
- verify_dnac_catalyst_center_system_health_no_critical_events.py
- verify_iosxe_no_critical_errors_in_system_logs.py

this PR also depends on https://github.com/netascode/nac-test-pyats-common/pull/6 and a subsequent release of nac-test-pyats-common so we can bump the dependency, so pipeline tests will fail until this is done. 
