### PR TITLE
fix(testbed): add defensive error handling for user-provided testbed loading

### DIFF
--- a/nac_test/pyats_core/execution/device/testbed_generator.py
+++ b/nac_test/pyats_core/execution/device/testbed_generator.py
@@ -180,12 +180,18 @@ class TestbedGenerator:
             guaranteed to exist as dictionaries.
 
         Raises:
-            ValueError: If the file contains invalid YAML, is empty,
-                or has unexpected structure.
+            ValueError: If the file contains invalid UTF-8 encoding, invalid YAML,
+                is empty, or has unexpected structure.
         """
+        # Typer CLI validates: exists=True, file_okay=True, dir_okay=False (readable)
         try:
             with open(base_testbed_path, encoding="utf-8") as f:
                 testbed = yaml.safe_load(f)
+        except UnicodeDecodeError as e:
+            raise ValueError(
+                f"Testbed file '{base_testbed_path}' contains invalid UTF-8 encoding. "
+                f"Please ensure the file is saved as UTF-8."
+            ) from e
         except yaml.YAMLError as e:
             raise ValueError(
                 f"Invalid YAML syntax in testbed file '{base_testbed_path}': {e}"

--- a/tests/unit/test_testbed_generator_merge.py
+++ b/tests/unit/test_testbed_generator_merge.py
@@ -621,3 +621,15 @@ custom_key: some_value
                         assert result[key][subkey] == subval
             else:
                 assert result[key] == expected
+
+    def test_unicode_decode_error(
+        self, tmp_path: Path, sample_device: dict[str, Any]
+    ) -> None:
+        """Test that non-UTF-8 files raise ValueError with encoding message."""
+        testbed_file = tmp_path / "invalid_encoding.yaml"
+        testbed_file.write_bytes(b"testbed:\n  name: \xff\xfe invalid utf-8\n")
+
+        with pytest.raises(ValueError, match="invalid UTF-8 encoding"):
+            TestbedGenerator.generate_consolidated_testbed_yaml(
+                [sample_device], base_testbed_path=testbed_file
+            )


### PR DESCRIPTION
## Summary

Add defensive error handling and negative test cases for the user-provided testbed YAML loading feature introduced in PR #458.

Fixes #480

## Changes

### Error Handling Improvements in `_load_user_testbed()`

- Add explicit `encoding="utf-8"` to file open operations
- Wrap `yaml.safe_load()` in try/except to catch `yaml.YAMLError` with user-friendly error messages
- Validate that loaded YAML is a `dict` before attempting to access keys
- Handle edge case where YAML file is empty (returns `None`)
- Validate that `devices` key (if present) is a `dict`
- Guarantee `testbed` and `devices` keys exist as dicts to avoid code duplication in callers

### Negative Test Cases Added

| Test | Description |
|------|-------------|
| `test_malformed_yaml_syntax` | Malformed YAML (consolidated method) |
| `test_malformed_yaml_syntax_single_device` | Malformed YAML (single device method) |
| `test_empty_yaml_file` | Empty file (consolidated) |
| `test_empty_yaml_file_single_device` | Empty file (single device) |
| `test_yaml_with_only_comments` | File with only comments |
| `test_yaml_contains_list_instead_of_dict` | List at root level |
| `test_yaml_contains_string_instead_of_dict` | String at root level |
| `test_yaml_contains_integer_instead_of_dict` | Integer at root level |
| `test_devices_key_is_string_instead_of_dict` | `devices: "string"` |
| `test_devices_key_is_list_instead_of_dict` | `devices: [...]` |
| `test_devices_key_is_integer_instead_of_dict` | `devices: 123` |
| `test_error_message_includes_file_path` | Verifies helpful error messages |
| `test_load_user_testbed_guarantees_testbed_key` | Verifies `testbed` key created |
| `test_load_user_testbed_guarantees_devices_key` | Verifies `devices` key created |
| `test_load_user_testbed_guarantees_both_keys_minimal_yaml` | Verifies both keys from minimal YAML |

## Testing

All 43 testbed-related tests pass:
- 20 original tests in `test_testbed_generator.py`
- 8 existing tests in `test_testbed_generator_merge.py`
- 15 new tests in `test_testbed_generator_merge.py`