### PR TITLE
docs: align jobfile examples with pyats.easypy.run

### DIFF
--- a/dev-docs/PRD_AND_ARCHITECTURE.md
+++ b/dev-docs/PRD_AND_ARCHITECTURE.md
@@ -3185,6 +3185,8 @@ class JobGenerator:
 ```python
 """Auto-generated PyATS job file by nac-test"""
 
+from pyats.easypy import run
+
 TEST_FILES = [
     "/path/to/test1.py",
     "/path/to/test2.py"
@@ -3194,7 +3196,7 @@ def main(runtime):
     runtime.max_workers = {max_workers}
     for test_file in TEST_FILES:
         test_name = Path(test_file).stem
-        runtime.tasks.run(
+        run(
             testscript=test_file,
             taskid=test_name,
             max_runtime={timeout}
@@ -3209,6 +3211,8 @@ def main(runtime):
 import os
 import json
 
+from pyats.easypy import run
+
 HOSTNAME = "{hostname}"
 DEVICE_INFO = {device_json}
 TEST_FILES = [...]
@@ -3219,7 +3223,7 @@ def main(runtime):
 
     for test_file in TEST_FILES:
         test_name = Path(test_file).stem
-        runtime.tasks.run(
+        run(
             testscript=test_file,
             taskid=f"{HOSTNAME}_{test_name}",
             max_runtime={timeout}
@@ -10974,7 +10978,7 @@ PyATS requires a "job file" - Python code that defines what tests to run and how
 **What is a PyATS job file?**
 
 A PyATS job file is a Python script with a `main(runtime)` function that:
-- Registers test files to execute via `runtime.tasks.run()`
+- Registers test files to execute via `pyats.easypy.run()`
 - Configures parallel worker count via `runtime.max_workers`
 - Sets per-test timeouts via `max_runtime` parameter
 - Optionally sets up shared resources (connection managers, testbeds)
@@ -10992,6 +10996,8 @@ def generate_job_file_content(self, test_files: List[Path]) -> str:
     job_content = textwrap.dedent(f'''
     """Auto-generated PyATS job file by nac-test"""
 
+    from pyats.easypy import run
+
     # Test files to execute
     TEST_FILES = [{test_files_str}]
 
@@ -11000,7 +11006,7 @@ def generate_job_file_content(self, test_files: List[Path]) -> str:
 
         for idx, test_file in enumerate(TEST_FILES):
             test_name = Path(test_file).stem
-            runtime.tasks.run(
+            run(
                 testscript=test_file,
                 taskid=test_name,
                 max_runtime={DEFAULT_TEST_TIMEOUT}
@@ -11039,6 +11045,7 @@ pyats run job {job_file} --archive-name {name}
 
 import os
 from pathlib import Path
+from pyats.easypy import run
 
 # Test files to execute (absolute paths)
 TEST_FILES = [
@@ -11060,7 +11067,7 @@ def main(runtime):
         # Create meaningful task ID from test file name
         # e.g., "epg_attributes.py" -> "epg_attributes"
         test_name = Path(test_file).stem
-        runtime.tasks.run(
+        run(
             testscript=test_file,
             taskid=test_name,
             max_runtime=21600  # 6 hours per test
@@ -11130,8 +11137,9 @@ pyats run job {job_file} --testbed-file {testbed} --archive-name device_{hostnam
 
 import os
 import json
-from pathlib import Path
-from nac_test.pyats_core.ssh.connection_manager import DeviceConnectionManager
+    from pathlib import Path
+    from pyats.easypy import run
+    from nac_test.pyats_core.ssh.connection_manager import DeviceConnectionManager
 
 # Device being tested (using hostname)
 HOSTNAME = "apic1"
@@ -11164,7 +11172,7 @@ def main(runtime):
         # Create meaningful task ID from test file name and hostname
         # e.g., "apic1_fabric_health_ssh"
         test_name = Path(test_file).stem
-        runtime.tasks.run(
+        run(
             testscript=test_file,
             taskid=f"{HOSTNAME}_{test_name}",
             max_runtime=21600  # 6 hours per test
@@ -11432,11 +11440,11 @@ PyATS executes test files in parallel using a worker pool. `max_workers` determi
 DEFAULT_TEST_TIMEOUT = 21600  # 6 hours per test
 ```
 
-**Injected into every `runtime.tasks.run()` call:**
+**Injected into every `pyats.easypy.run()` call:**
 
 ```python
 # job_generator.py:67
-runtime.tasks.run(
+run(
     testscript=test_file,
     taskid=test_name,
     max_runtime={DEFAULT_TEST_TIMEOUT}  # 21600 seconds = 6 hours
@@ -11513,8 +11521,9 @@ cat /tmp/tmpXYZ_api_job.py
 ```python
 """Auto-generated PyATS job file by nac-test"""
 
-import os
-from pathlib import Path
+    import os
+    from pathlib import Path
+    from pyats.easypy import run
 
 # Test files to execute
 TEST_FILES = [
@@ -11528,7 +11537,7 @@ def main(runtime):
 
     for idx, test_file in enumerate(TEST_FILES):
         test_name = Path(test_file).stem
-        runtime.tasks.run(
+        run(
             testscript=test_file,
             taskid=test_name,
             max_runtime=21600
@@ -11542,7 +11551,8 @@ def main(runtime):
 
 # Step 1: Generate job file manually using Python
 python3 << 'EOF'
-from pathlib import Path
+    from pathlib import Path
+    from pyats.easypy import run
 from nac_test.pyats_core.execution.job_generator import JobGenerator
 
 generator = JobGenerator(max_workers=8, output_dir=Path("output/pyats_results"))
@@ -11590,7 +11600,7 @@ def main(runtime):
     runtime.max_workers = 2
 
     # Run only the failing test
-    runtime.tasks.run(
+    run(
         testscript="/home/user/tests/api/verify_aci_bridge_domains.py",
         taskid="debug_bridge_domains",
         max_runtime=3600  # 1 hour timeout for debugging
@@ -11640,8 +11650,8 @@ def main(runtime):
     runtime.max_workers = 16  # Hardcoded!
 
     # Hardcoded test list - requires manual updates
-    runtime.tasks.run(testscript="test1.py", taskid="test1")
-    runtime.tasks.run(testscript="test2.py", taskid="test2")
+    run(testscript="test1.py", taskid="test1")
+    run(testscript="test2.py", taskid="test2")
 ```
 
 **Problems:**
@@ -17204,7 +17214,7 @@ def main(runtime):
 
     for idx, test_file in enumerate(TEST_FILES):
         test_name = Path(test_file).stem
-        runtime.tasks.run(
+        run(
             testscript=test_file,
             taskid=test_name,
             max_runtime=21600  # 6 hours


### PR DESCRIPTION
## Description
Update PRD_AND_ARCHITECTURE jobfile examples to use `pyats.easypy.run` (documented entrypoint) with explicit imports, aligning docs with expected usage while preserving runtime behavior.

## Related Issue(s)
- Fixes #477
- Related to #

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Technical debt (internal improvements with no user-facing changes)
- [x] Documentation update
- [ ] Chore (build process, CI, tooling, dependencies)
- [ ] Other (please describe):

## Test Framework Affected
- [x] PyATS
- [ ] Robot Framework
- [ ] Both
- [ ] N/A (not test-framework specific)

## Network as Code (NaC) Architecture Affected
- [ ] ACI (APIC)
- [ ] NDO (Nexus Dashboard Orchestrator)
- [ ] NDFC / VXLAN-EVPN (Nexus Dashboard Fabric Controller)
- [ ] Catalyst SD-WAN (SDWAN Manager / vManage)
- [ ] Catalyst Center (DNA Center)
- [ ] ISE (Identity Services Engine)
- [ ] FMC (Firewall Management Center)
- [ ] Meraki (Cloud-managed)
- [ ] NX-OS (Nexus Direct-to-Device)
- [ ] IOS-XE (Direct-to-Device)
- [ ] IOS-XR (Direct-to-Device)
- [ ] Hyperfabric
- [ ] All architectures
- [x] N/A (architecture-agnostic)

## Platform Tested

> nac-test supports macOS and Linux only

- [ ] macOS (version tested: )
- [ ] Linux (distro/version tested: )

## Key Changes
- Update jobfile example snippets to call `pyats.easypy.run(...)` instead of `runtime.tasks.run(...)`.
- Add `from pyats.easypy import run` imports to example jobfiles.
- Align doc text references to `pyats.easypy.run()` in the jobfile generation section.

## Testing Done
- [ ] Unit tests added/updated
- [ ] Integration tests performed
- [ ] Manual testing performed:
  - [ ] PyATS tests executed successfully
  - [ ] Robot Framework tests executed successfully
  - [ ] D2D/SSH tests executed successfully (if applicable)
  - [ ] HTML reports generated correctly
- [ ] All existing tests pass (`pytest` / `pre-commit run -a`)

### Test Commands Used


 Not run (documentation-only change; no test targets available)

## Checklist
- [ ] Code follows project style guidelines (`pre-commit run -a` passes)
- [ ] Self-review of code completed
- [ ] Code is commented where necessary (especially complex logic)
- [x] Documentation updated (if applicable)
- [ ] No new warnings introduced
- [ ] Changes work on both macOS and Linux
- [ ] CHANGELOG.md updated (if applicable)

## Screenshots (if applicable)

<!-- Add screenshots for UI/report changes -->

## Additional Notes
- Documentation-only update; no code changes needed.
- `pyats.easypy.run` is the documented entrypoint and is functionally equivalent to `runtime.tasks.run` (bound alias).