### PR TITLE
fix(tests): isolate temp file tests to prevent parallel race conditions

### DIFF
--- a/tests/pyats_core/common/test_auth_cache.py
+++ b/tests/pyats_core/common/test_auth_cache.py
@@ -15,19 +15,17 @@ authentication caching for parallel processes. The tests cover:
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
+from pytest_mock import MockerFixture
 
 from nac_test.pyats_core.common.auth_cache import AuthCache
 
-if TYPE_CHECKING:
-    from pytest_mock.plugin import MockerFixture
-
 
 @pytest.fixture
-def mock_time(mocker: "MockerFixture") -> Any:
+def mock_time(mocker: MockerFixture) -> Any:
     """Fixture to mock time.time() for testing TTL behavior.
 
     Args:
@@ -42,7 +40,7 @@ def mock_time(mocker: "MockerFixture") -> Any:
 
 
 @pytest.fixture
-def mock_auth_cache_dir(mocker: "MockerFixture", tmp_path: Path) -> Path:
+def mock_auth_cache_dir(mocker: MockerFixture, tmp_path: Path) -> Path:
     """Fixture to provide a temporary auth cache directory.
 
     Args:
@@ -59,7 +57,7 @@ def mock_auth_cache_dir(mocker: "MockerFixture", tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def mock_fcntl(mocker: "MockerFixture") -> Any:
+def mock_fcntl(mocker: MockerFixture) -> Any:
     """Fixture to mock file locking operations.
 
     Note: This fixture now mocks filelock.FileLock instead of fcntl.flock,
@@ -595,7 +593,7 @@ class TestAuthCachePublicMethods:
     """Test cases for the public methods of AuthCache."""
 
     def test_get_or_create_calls_internal_correctly(
-        self, mocker: "MockerFixture"
+        self, mocker: MockerFixture
     ) -> None:
         """Test that get_or_create calls _cache_auth_data with correct parameters.
 
@@ -631,7 +629,7 @@ class TestAuthCachePublicMethods:
         )
 
     def test_get_or_create_token_calls_internal_correctly(
-        self, mocker: "MockerFixture"
+        self, mocker: MockerFixture
     ) -> None:
         """Test that get_or_create_token calls _cache_auth_data with correct parameters.
 
@@ -874,7 +872,7 @@ class TestAuthCacheIntegration:
         self,
         mock_auth_cache_dir: Path,
         mock_fcntl: Mock,
-        mocker: "MockerFixture",
+        mocker: MockerFixture,
         initial_time: float,
         check_time: float,
         should_refresh: bool,
@@ -960,7 +958,7 @@ class TestAuthCacheErrorHandling:
             )
 
     def test_cache_dir_creation(
-        self, mocker: "MockerFixture", tmp_path: Path, mock_fcntl: Mock, mock_time: Mock
+        self, mocker: MockerFixture, tmp_path: Path, mock_fcntl: Mock, mock_time: Mock
     ) -> None:
         """Test that cache directory is created if it doesn't exist.
 

--- a/tests/pyats_core/common/test_subprocess_auth.py
+++ b/tests/pyats_core/common/test_subprocess_auth.py
@@ -12,9 +12,10 @@ Tests the fork-safe subprocess authentication mechanism:
 import os
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import pytest
+from pytest_mock import MockerFixture
 
 from nac_test.pyats_core.common.subprocess_auth import (
     SubprocessAuthError,
@@ -22,12 +23,9 @@ from nac_test.pyats_core.common.subprocess_auth import (
     execute_auth_subprocess,
 )
 
-if TYPE_CHECKING:
-    from pytest_mock.plugin import MockerFixture
-
 
 @pytest.fixture
-def isolated_tempfile(mocker: "MockerFixture", tmp_path: Path) -> Path:
+def isolated_tempfile(mocker: MockerFixture, tmp_path: Path) -> Path:
     """Redirect tempfile.NamedTemporaryFile to isolated test directory.
 
     Prevents race conditions when tests run in parallel by ensuring each

--- a/tests/pyats_core/common/test_subprocess_http_client.py
+++ b/tests/pyats_core/common/test_subprocess_http_client.py
@@ -9,19 +9,15 @@ Tests the fork-safe HTTP client:
 3. ConnectionPool platform-specific client selection
 """
 
-from typing import TYPE_CHECKING
-
 import httpx
 import pytest
+from pytest_mock import MockerFixture
 
 from nac_test.pyats_core.common.connection_pool import ConnectionPool
 from nac_test.pyats_core.http import (
     SubprocessHttpClient,
     SubprocessResponse,
 )
-
-if TYPE_CHECKING:
-    from pytest_mock.plugin import MockerFixture
 
 
 class TestSubprocessResponseRaiseForStatus:
@@ -83,7 +79,7 @@ class TestSubprocessHttpClientUrlResolution:
 class TestConnectionPoolPlatformSelection:
     """Tests for ConnectionPool client selection based on platform."""
 
-    def test_returns_subprocess_client_on_darwin(self, mocker: "MockerFixture") -> None:
+    def test_returns_subprocess_client_on_darwin(self, mocker: MockerFixture) -> None:
         """Verify SubprocessHttpClient is returned on macOS (fork-safety)."""
         mocker.patch(
             "nac_test.pyats_core.common.connection_pool.platform.system",
@@ -98,7 +94,7 @@ class TestConnectionPoolPlatformSelection:
 
         assert isinstance(client, SubprocessHttpClient)
 
-    def test_returns_httpx_client_on_linux(self, mocker: "MockerFixture") -> None:
+    def test_returns_httpx_client_on_linux(self, mocker: MockerFixture) -> None:
         """Verify httpx.AsyncClient is returned on Linux."""
         mocker.patch(
             "nac_test.pyats_core.common.connection_pool.platform.system",
@@ -113,7 +109,7 @@ class TestConnectionPoolPlatformSelection:
 
         assert isinstance(client, httpx.AsyncClient)
 
-    def test_returns_httpx_client_on_windows(self, mocker: "MockerFixture") -> None:
+    def test_returns_httpx_client_on_windows(self, mocker: MockerFixture) -> None:
         """Verify httpx.AsyncClient is returned on Windows."""
         mocker.patch(
             "nac_test.pyats_core.common.connection_pool.platform.system",


### PR DESCRIPTION
Fixes #568

## Description

Fixes flaky `test_temp_files_cleaned_up_on_success` and `test_temp_files_cleaned_up_on_error` tests that failed intermittently when running with `pytest-xdist`. The tests used the global system temp directory to count files, causing race conditions when other parallel tests created/deleted files with similar patterns.

Solution: Patch `tempfile.NamedTemporaryFile` to redirect temp file creation to pytest's `tmp_path` fixture, providing an isolated empty directory per test.

## Closes

- Fixes #568

## Related Issue(s)

- N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Technical debt (internal improvements with no user-facing changes)
- [ ] Documentation update
- [ ] Chore (build process, CI, tooling, dependencies)
- [ ] Other (please describe):

## Test Framework Affected

- [x] PyATS
- [ ] Robot Framework
- [ ] Both
- [ ] N/A (not test-framework specific)

## Network as Code (NaC) Architecture Affected

- [ ] ACI (APIC)
- [ ] NDO (Nexus Dashboard Orchestrator)
- [ ] NDFC / VXLAN-EVPN (Nexus Dashboard Fabric Controller)
- [ ] Catalyst SD-WAN (SDWAN Manager / vManage)
- [ ] Catalyst Center (DNA Center)
- [ ] ISE (Identity Services Engine)
- [ ] FMC (Firepower Management Center)
- [ ] Meraki (Cloud-managed)
- [ ] NX-OS (Nexus Direct-to-Device)
- [ ] IOS-XE (Direct-to-Device)
- [ ] IOS-XR (Direct-to-Device)
- [ ] Hyperfabric
- [ ] All architectures
- [x] N/A (architecture-agnostic)

## Platform Tested

- [x] macOS (version tested: macOS on Apple Silicon)
- [ ] Linux (distro/version tested: )

## Key Changes

- Modified `test_temp_files_cleaned_up_on_success` to use `tmp_path` fixture with `unittest.mock.patch.object` to isolate temp file creation
- Modified `test_temp_files_cleaned_up_on_error` with same isolation pattern
- Added comments explaining the patch with reference to issue #568

## Testing Done

- [x] Unit tests added/updated
- [ ] Integration tests performed
- [ ] Manual testing performed:
  - [ ] PyATS tests executed successfully
  - [ ] Robot Framework tests executed successfully
  - [ ] D2D/SSH tests executed successfully (if applicable)
  - [ ] HTML reports generated correctly
- [x] All existing tests pass (`pytest` / `pre-commit run -a`)

### Test Commands Used

```bash
uv run pytest -n auto --dist loadscope
# Result: 673 passed
```

## Checklist

- [x] Code follows project style guidelines (`pre-commit run -a` passes)
- [x] Self-review of code completed
- [x] Code is commented where necessary (especially complex logic)
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced
- [ ] Changes work on both macOS and Linux
- [ ] CHANGELOG.md updated (if applicable)

## Screenshots (if applicable)

N/A

## Additional Notes

This fix was discovered during PR #529 CI run. The original failure showed:
```
auth_files_after = 0, auth_files_before = 2
assert auth_files_after == auth_files_before
AssertionError: assert 0 == 2
```

The root cause was that another parallel test created 2 auth-related temp files, which were then cleaned up before our test finished counting.