### PR TITLE
fix(pyats): clean up stale test artifacts before execution (#526)

### DIFF
--- a/nac_test/pyats_core/orchestrator.py
+++ b/nac_test/pyats_core/orchestrator.py
@@ -41,7 +41,11 @@ from nac_test.pyats_core.reporting.multi_archive_generator import (
 )
 from nac_test.pyats_core.reporting.utils.archive_aggregator import ArchiveAggregator
 from nac_test.pyats_core.reporting.utils.archive_inspector import ArchiveInspector
-from nac_test.utils.cleanup import cleanup_old_test_outputs, cleanup_pyats_runtime
+from nac_test.utils.cleanup import (
+    cleanup_old_test_outputs,
+    cleanup_pyats_runtime,
+    cleanup_stale_test_artifacts,
+)
 from nac_test.utils.controller import detect_controller_type
 from nac_test.utils.environment import EnvironmentValidator
 from nac_test.utils.system_resources import SystemResourceCalculator
@@ -552,6 +556,10 @@ class PyATSOrchestrator:
 
         # Clean up before test execution
         cleanup_pyats_runtime()
+
+        # Clean up stale test artifacts (api/, d2d/ directories under output root)
+        # to prevent JSONL files from interrupted runs being picked up (fixes issue #526)
+        cleanup_stale_test_artifacts(self.base_output_dir)
 
         # Clean up old test outputs (CI/CD only)
         if os.environ.get("CI"):

--- a/nac_test/utils/__init__.py
+++ b/nac_test/utils/__init__.py
@@ -4,7 +4,11 @@
 """Utility modules for nac-test framework."""
 
 from nac_test.utils.asyncio_utils import get_or_create_event_loop
-from nac_test.utils.cleanup import cleanup_old_test_outputs, cleanup_pyats_runtime
+from nac_test.utils.cleanup import (
+    cleanup_old_test_outputs,
+    cleanup_pyats_runtime,
+    cleanup_stale_test_artifacts,
+)
 from nac_test.utils.controller import detect_controller_type
 from nac_test.utils.device_validation import (
     REQUIRED_DEVICE_FIELDS,
@@ -23,6 +27,7 @@ __all__ = [
     "EnvironmentValidator",
     "cleanup_pyats_runtime",
     "cleanup_old_test_outputs",
+    "cleanup_stale_test_artifacts",
     "configure_logging",
     "VerbosityLevel",
     # Asyncio utilities (cross-version compatibility)

--- a/nac_test/utils/cleanup.py
+++ b/nac_test/utils/cleanup.py
@@ -8,6 +8,8 @@ import shutil
 import time
 from pathlib import Path
 
+from nac_test.pyats_core.discovery.test_type_resolver import VALID_TEST_TYPES
+
 logger = logging.getLogger(__name__)
 
 
@@ -60,3 +62,46 @@ def cleanup_old_test_outputs(output_dir: Path, days: int = 7) -> None:
                 logger.debug(f"Removed old test output: {file.name}")
         except Exception:
             pass  # Best effort cleanup
+
+
+def cleanup_stale_test_artifacts(output_dir: Path) -> None:
+    """Clean up stale test artifacts that cause incorrect report aggregation.
+
+    Targets ONLY the test type directories (api/, d2d/, default/) which contain
+    html_report_data_temp/*.jsonl files from interrupted runs. These stale JSONL
+    files get picked up during report generation and cause incorrect results.
+
+    Does NOT remove:
+        - Archive files (nac_test_job_*.zip): The orchestrator's ArchiveInspector
+          uses only the newest archive per type, so old archives don't cause issues.
+        - pyats_results/ directory: This is unconditionally removed and recreated
+          during report generation (multi_archive_generator.py), so cleaning it
+          here provides no benefit.
+
+    Args:
+        output_dir: Base output directory for test results.
+    """
+    if not output_dir.exists():
+        return
+
+    # Clean up test type directories (api/, d2d/, default/)
+    # These contain html_report_data_temp/ with potentially stale JSONL files
+    # from interrupted test runs (e.g., Ctrl+C)
+    # "default" is a safety net for tests run outside orchestration (see base_test.py)
+    dirs_to_clean = (*VALID_TEST_TYPES, "default")
+    dirs_removed = 0
+
+    for dir_name in dirs_to_clean:
+        dir_path = output_dir / dir_name
+        if dir_path.exists():
+            try:
+                shutil.rmtree(dir_path, ignore_errors=True)
+                dirs_removed += 1
+                logger.debug(f"Removed stale test directory: {dir_path}")
+            except Exception as e:
+                logger.warning(f"Failed to clean directory {dir_path}: {e}")
+
+    if dirs_removed > 0:
+        logger.info(
+            f"Cleaned up {dirs_removed} stale test artifact director{'y' if dirs_removed == 1 else 'ies'}"
+        )

--- a/tests/utils/test_cleanup.py
+++ b/tests/utils/test_cleanup.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+"""Unit tests for cleanup utilities."""
+
+from pathlib import Path
+
+import pytest
+
+from nac_test.core.constants import PYATS_RESULTS_DIRNAME
+from nac_test.pyats_core.discovery.test_type_resolver import VALID_TEST_TYPES
+from nac_test.utils.cleanup import cleanup_stale_test_artifacts
+
+
+class TestCleanupStaleTestArtifacts:
+    """Tests for cleanup_stale_test_artifacts function."""
+
+    def test_removes_test_type_directories(self, tmp_path: Path) -> None:
+        """Test that api/, d2d/, default/ directories are removed."""
+        test_type_dirs = (*VALID_TEST_TYPES, "default")
+        for test_type in test_type_dirs:
+            test_type_dir = tmp_path / test_type
+            test_type_dir.mkdir()
+            (test_type_dir / "html_report_data_temp").mkdir()
+            (test_type_dir / "html_report_data_temp" / "stale.jsonl").touch()
+
+        cleanup_stale_test_artifacts(tmp_path)
+
+        for test_type in test_type_dirs:
+            assert not (tmp_path / test_type).exists()
+
+    @pytest.mark.parametrize(
+        "preserved_path,is_file",
+        [
+            ("nac_test_job_api_20250224.zip", True),
+            ("nac_test_job_d2d_20250224.zip", True),
+            (PYATS_RESULTS_DIRNAME, False),
+            ("robot_results", False),
+            ("merged_data_model.yaml", True),
+        ],
+    )
+    def test_preserves_expected_paths(
+        self, tmp_path: Path, preserved_path: str, is_file: bool
+    ) -> None:
+        """Test that archives, pyats_results, robot_results, and other files are preserved."""
+        path = tmp_path / preserved_path
+        if is_file:
+            path.touch()
+        else:
+            path.mkdir()
+            (path / "content.txt").touch()
+
+        (tmp_path / "api").mkdir()
+
+        cleanup_stale_test_artifacts(tmp_path)
+
+        assert path.exists()
+        assert not (tmp_path / "api").exists()
+
+    def test_handles_nonexistent_directory(self) -> None:
+        """Test that nonexistent directory is handled gracefully."""
+        cleanup_stale_test_artifacts(Path("/nonexistent/path"))
+
+    def test_handles_empty_directory(self, tmp_path: Path) -> None:
+        """Test that empty directory is handled gracefully."""
+        cleanup_stale_test_artifacts(tmp_path)
+        assert tmp_path.exists()


### PR DESCRIPTION
Fixes #526

## Description

When `nac-test` is interrupted (Ctrl+C) and restarted with the same output directory, stale `html_report_data_temp/*.jsonl` files from previous runs get picked up during report generation, causing incorrect results.

This PR adds `cleanup_stale_test_artifacts()` that removes ONLY the test type directories (`api/`, `d2d/`, `default/`) which contain these stale JSONL files.

**Intentionally does NOT remove:**
- **Archive files** (`nac_test_job_*.zip`): The `ArchiveInspector` sorts by mtime and only uses the newest archive per type, so old archives don't cause issues.
- **`pyats_results/` directory**: This is unconditionally removed and recreated during report generation (`multi_archive_generator.py`), so cleaning it here provides no benefit.

## Closes

- Fixes #526

## Related Issue(s)

- None

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Technical debt (internal improvements with no user-facing changes)
- [ ] Documentation update
- [ ] Chore (build process, CI, tooling, dependencies)
- [ ] Other (please describe):

## Test Framework Affected

- [x] PyATS
- [ ] Robot Framework
- [ ] Both
- [ ] N/A (not test-framework specific)

## Network as Code (NaC) Architecture Affected

- [ ] ACI (APIC)
- [ ] NDO (Nexus Dashboard Orchestrator)
- [ ] NDFC / VXLAN-EVPN (Nexus Dashboard Fabric Controller)
- [ ] Catalyst SD-WAN (SDWAN Manager / vManage)
- [ ] Catalyst Center (DNA Center)
- [ ] ISE (Identity Services Engine)
- [ ] FMC (Firepower Management Center)
- [ ] Meraki (Cloud-managed)
- [ ] NX-OS (Nexus Direct-to-Device)
- [ ] IOS-XE (Direct-to-Device)
- [ ] IOS-XR (Direct-to-Device)
- [ ] Hyperfabric
- [ ] All architectures
- [x] N/A (architecture-agnostic)

## Platform Tested

- [x] macOS (version tested: darwin/arm64)
- [ ] Linux (distro/version tested: )

## Key Changes

- Add `cleanup_stale_test_artifacts()` in `nac_test/utils/cleanup.py`
- Clean up test type directories (`api/`, `d2d/`, `default/`) containing stale JSONL files
- Use `VALID_TEST_TYPES` from `test_type_resolver` as source of truth
- Preserve existing `cleanup_old_test_outputs()` for CI time-based cleanup
- Add 8 unit tests with pytest parametrization for cleanup functionality

## Testing Done

- [x] Unit tests added/updated
- [ ] Integration tests performed
- [x] Manual testing performed:
  - [x] PyATS tests executed successfully
  - [ ] Robot Framework tests executed successfully
  - [ ] D2D/SSH tests executed successfully (if applicable)
  - [x] HTML reports generated correctly
- [x] All existing tests pass (`pytest` / `pre-commit run -a`)

### Test Commands Used

```bash
pre-commit run --all-files
uv run pytest -n auto --dist loadscope
```

## Checklist

- [x] Code follows project style guidelines (`pre-commit run -a` passes)
- [x] Self-review of code completed
- [x] Code is commented where necessary (especially complex logic)
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced
- [ ] Changes work on both macOS and Linux
- [ ] CHANGELOG.md updated (if applicable)

## Screenshots (if applicable)

N/A

## Additional Notes

- The `"default"` directory is included as a safety net for tests run outside orchestration (see `base_test.py`)
- This targeted approach addresses reviewer feedback about preserving archive history
