### PR TITLE
fix(test): skip performance test on Python 3.13 + GitHub Actions + xdist

### DIFF
--- a/tests/integration/test_discovery_integration.py
+++ b/tests/integration/test_discovery_integration.py
@@ -17,6 +17,7 @@ Test Categories:
     - TestEdgeCases: Tests mixed scenarios and error handling
     - TestRelaxedPathRequirements: Tests for issue #475 - arbitrary directory naming
     - TestExcludePaths: Tests directory exclusion functionality
+    - TestDiscoveryPerformance: Performance tests for discovery mechanism
 """
 
 import os
@@ -694,7 +695,7 @@ class TestDiscoveryPerformance:
         sys.version_info[:2] == (3, 13)
         and os.environ.get("GITHUB_ACTIONS") is not None
         and os.environ.get("PYTEST_XDIST_WORKER") is not None,
-        reason="pytest-xdist causes inconclusive performance results on Python 3.13 in GitHub Actions CI (see #589)",
+        reason="pytest-xdist causes ~1500x AST parse slowdown on Python 3.13 in GitHub Actions; results are inconclusive)",
     )
     def test_categorization_performance(self, tmp_path: Path) -> None:
         """Test that categorization completes quickly even with many files.


### PR DESCRIPTION
Fixes #589

## Description

Skip `test_categorization_performance` when running on Python 3.13 in GitHub Actions CI with pytest-xdist active.

pytest-xdist causes ~1500x performance degradation for AST-based tests specifically on Python 3.13 in GitHub Actions. The results are inconclusive in this environment, so adjusting the threshold is not meaningful.

## Closes

- Fixes #589

## Related Issue(s)

- N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Technical debt (internal improvements with no user-facing changes)
- [ ] Documentation update
- [ ] Chore (build process, CI, tooling, dependencies)
- [ ] Other (please describe):

## Test Framework Affected

- [ ] PyATS
- [ ] Robot Framework
- [ ] Both
- [x] N/A (not test-framework specific)

## Network as Code (NaC) Architecture Affected

- [ ] ACI (APIC)
- [ ] NDO (Nexus Dashboard Orchestrator)
- [ ] NDFC / VXLAN-EVPN (Nexus Dashboard Fabric Controller)
- [ ] Catalyst SD-WAN (SDWAN Manager / vManage)
- [ ] Catalyst Center (DNA Center)
- [ ] ISE (Identity Services Engine)
- [ ] FMC (Firepower Management Center)
- [ ] Meraki (Cloud-managed)
- [ ] NX-OS (Nexus Direct-to-Device)
- [ ] IOS-XE (Direct-to-Device)
- [ ] IOS-XR (Direct-to-Device)
- [ ] Hyperfabric
- [ ] All architectures
- [x] N/A (architecture-agnostic)

## Platform Tested

> nac-test supports macOS and Linux only

- [x] macOS (version tested: Sequoia 15.3)
- [x] Linux (distro/version tested: GitHub Actions ubuntu-latest)

## Key Changes

- Added `@pytest.mark.skipif` decorator to `test_categorization_performance` with three conditions:
  - Python 3.13 (`sys.version_info[:2] == (3, 13)`)
  - GitHub Actions CI (`GITHUB_ACTIONS=true`)
  - pytest-xdist active (`PYTEST_XDIST_WORKER` is set)
- Reverted previous approach that split test execution

## Testing Done

- [x] Unit tests added/updated
- [x] Integration tests performed
- [x] Manual testing performed:
  - [ ] PyATS tests executed successfully
  - [ ] Robot Framework tests executed successfully
  - [ ] D2D/SSH tests executed successfully (if applicable)
  - [ ] HTML reports generated correctly
- [x] All existing tests pass (pytest / pre-commit run -a)

### Test Commands Used

```bash
# Local test run (Python 3.12) - test executes normally
uv run pytest tests/integration/test_discovery_integration.py::TestDiscoveryPerformance -v
```

## Checklist

- [x] Code follows project style guidelines (pre-commit run -a passes)
- [x] Self-review of code completed
- [x] Code is commented where necessary (especially complex logic)
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Changes work on both macOS and Linux
- [ ] CHANGELOG.md updated (if applicable)

## Screenshots (if applicable)

N/A

## Additional Notes

**Why skip instead of adjusting the threshold?**

The performance results on Python 3.13 + GitHub Actions + pytest-xdist are inconclusive (~1500x variance). Adjusting the threshold to accommodate this would defeat the purpose of the performance test.

**Why these specific conditions?**

- The test passes locally on Python 3.13 (without xdist or with `-n 0`)
- The test currently only fails on github-action CI, so would assume this is specific to this environment
- The issue is specific to the combination of all three factors

**Profiling data collected in issue #589.**