### PR TITLE
feat(deps): use new nac-yaml 2.0a0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "Jinja2>=3.1.6",
     "jmespath>=1.0.1",
     "nac-test-pyats-common>=0.3.0",
-    "nac-yaml>=1.1.1",
+    "nac-yaml==2.0.0a0",
     "robotframework>=7.3.2",
     "robotframework-jmespath",
     "robotframework-jsonlibrary>=0.5",

--- a/tests/integration/fixtures/data_merge/result.yaml
+++ b/tests/integration/fixtures/data_merge/result.yaml
@@ -14,6 +14,5 @@ root:
   dict_list_extra:
     - name: abc
       extra1: def
-    - name: abc
       extra2: ghi
   attr2: value2

--- a/uv.lock
+++ b/uv.lock
@@ -1873,7 +1873,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.17.1" },
     { name = "nac-test-pyats-common", specifier = ">=0.3.0" },
     { name = "nac-test-pyats-common", marker = "extra == 'dev'", specifier = ">=0.1.0" },
-    { name = "nac-yaml", specifier = ">=1.1.1" },
+    { name = "nac-yaml", specifier = "==2.0.0a0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.3.0" },
     { name = "psutil", specifier = ">=7.0.0" },
     { name = "pyats", marker = "sys_platform != 'win32'", specifier = ">=25.5" },
@@ -1915,14 +1915,14 @@ wheels = [
 
 [[package]]
 name = "nac-yaml"
-version = "1.1.1"
+version = "2.0.0a0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ruamel-yaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/fa/b3edf92821c676c24be3259acba5d7e7520453cd35da9c73fbd02849b96a/nac_yaml-1.1.1.tar.gz", hash = "sha256:8ecb89439703aa7e55018ead08e7b2ba0515cabbe8b1ff78d717f5ee15b0220e", size = 61000, upload-time = "2025-10-10T15:25:33.162Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/0e/c9ccec9707bcd18a5a4feea304bba982e2ea9f4f9c09f794e3deaf1b2ca9/nac_yaml-2.0.0a0.tar.gz", hash = "sha256:4c3d81035d2a1635b97548293dfa944c566ff221552231e03dffcfc0c707d051", size = 68249, upload-time = "2026-03-10T09:05:17.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/b2/c1ee7971e6e55558ae7cb72acae19f301f06cb8d6c63ec7922eb580d2436/nac_yaml-1.1.1-py3-none-any.whl", hash = "sha256:e5c20642b3a5f745d8620eb41ea5efccc9a62b2a3568f8e08e268f89394a0862", size = 9403, upload-time = "2025-10-10T15:25:32.375Z" },
+    { url = "https://files.pythonhosted.org/packages/05/15/c8cac560f03fa6744ddd942422167773c36e351629cdf353afafb87c0f85/nac_yaml-2.0.0a0-py3-none-any.whl", hash = "sha256:d641843618362808f38c656303f6a77fc5bfcaf0ddfd336709cdaf18d39a21cd", size = 12781, upload-time = "2026-03-10T09:05:16.466Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Pin nac-yaml dependency to version 2.0.0a0 to prepare for the upcoming nac-yaml 2.0 release with improved YAML merging behavior.

## Closes

- Fixes #542

## Related Issue(s)

-

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Technical debt (internal improvements with no user-facing changes)
- [ ] Documentation update
- [x] Chore (build process, CI, tooling, dependencies)
- [ ] Other (please describe):

## Test Framework Affected

- [ ] PyATS
- [ ] Robot Framework
- [x] Both
- [ ] N/A (not test-framework specific)

## Network as Code (NaC) Architecture Affected

- [ ] ACI (APIC)
- [ ] NDO (Nexus Dashboard Orchestrator)
- [ ] NDFC / VXLAN-EVPN (Nexus Dashboard Fabric Controller)
- [ ] Catalyst SD-WAN (SDWAN Manager / vManage)
- [ ] Catalyst Center (DNA Center)
- [ ] ISE (Identity Services Engine)
- [ ] FMC (Firepower Management Center)
- [ ] Meraki (Cloud-managed)
- [ ] NX-OS (Nexus Direct-to-Device)
- [ ] IOS-XE (Direct-to-Device)
- [ ] IOS-XR (Direct-to-Device)
- [ ] Hyperfabric
- [ ] All architectures
- [x] N/A (architecture-agnostic)

## Platform Tested

- [x] macOS (version tested: darwin)
- [ ] Linux (distro/version tested: )

## Key Changes

- **pyproject.toml**: Changed `nac-yaml>=1.1.1` to `nac-yaml==2.0.0a0` to pin the exact pre-release version
- **uv.lock**: Regenerated lock file with nac-yaml 2.0.0a0
- **tests/integration/fixtures/data_merge/result.yaml**: Updated expected merge result to match nac-yaml 2.0.0a0 behavior

### Behavior Change in nac-yaml 2.0.0a0

The new nac-yaml version changes list merging behavior: dictionary items within lists that have matching key values (e.g., `name: abc`) are now **merged together** instead of being kept as separate entries. This is a breaking change in YAML merge semantics.

**Before (nac-yaml 1.x):**
```yaml
dict_list_extra:
  - name: abc
    extra1: def
  - name: abc
    extra2: ghi
```

**After (nac-yaml 2.0.0a0):**
```yaml
dict_list_extra:
  - name: abc
    extra1: def
    extra2: ghi
```

## Testing Done

- [ ] Unit tests added/updated
- [x] Integration tests performed
- [ ] Manual testing performed:
  - [ ] PyATS tests executed successfully
  - [ ] Robot Framework tests executed successfully
  - [ ] D2D/SSH tests executed successfully (if applicable)
  - [ ] HTML reports generated correctly
- [x] All existing tests pass (`pytest` / `pre-commit run -a`)

### Test Commands Used

```bash
uv lock
uv run pytest tests/unit -n auto --dist loadscope -v     # 665 passed
uv run pytest tests/integration -n auto --dist loadscope -v  # 75 passed
```

## Checklist

- [x] Code follows project style guidelines (`pre-commit run -a` passes)
- [x] Self-review of code completed
- [x] Code is commented where necessary (especially complex logic)
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced
- [ ] Changes work on both macOS and Linux
- [ ] CHANGELOG.md updated (if applicable)

## Additional Notes

The test fixture update was required because the expected merge result needed to reflect the new nac-yaml 2.0.0a0 merging semantics. This is an intentional behavior change in the nac-yaml library.