### PR TITLE
fix(pyats): prevent credential exposure in PyATS archives (#689)

### DIFF
--- a/nac_test/pyats_core/execution/subprocess_runner.py
+++ b/nac_test/pyats_core/execution/subprocess_runner.py
@@ -141,6 +141,8 @@ class SubprocessRunner:
                     enabled: True
                     module: nac_test.pyats_core.progress.plugin
                     order: 1.0
+                EnvironmentDebugPlugin:
+                    enabled: False
             """)
 
             with tempfile.NamedTemporaryFile(
@@ -249,6 +251,8 @@ class SubprocessRunner:
                     enabled: True
                     module: nac_test.pyats_core.progress.plugin
                     order: 1.0
+                EnvironmentDebugPlugin:
+                    enabled: False
             """)
 
             with tempfile.NamedTemporaryFile(

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -42,6 +42,10 @@ from tests.e2e.config import (
 )
 from tests.e2e.mocks.mock_server import MockAPIServer
 
+# Sentinel value for credential exposure detection (#689)
+# All test passwords use this value so we can detect if credentials leak into artifacts
+TEST_CREDENTIAL_SENTINEL = "CRED_SENTINEL_MUST_NOT_APPEAR_IN_ARTIFACTS"
+
 
 @dataclass
 class E2EResults:
@@ -224,10 +228,10 @@ def _run_e2e_scenario(
     else:
         class_mocker.setenv(f"{arch}_URL", "http://dry-run.invalid")
     class_mocker.setenv(f"{arch}_USERNAME", "mock_user")
-    class_mocker.setenv(f"{arch}_PASSWORD", "mock_pass")
+    class_mocker.setenv(f"{arch}_PASSWORD", TEST_CREDENTIAL_SENTINEL)
     # IOSXE credentials needed for D2D tests (device access)
     class_mocker.setenv("IOSXE_USERNAME", "mock_user")
-    class_mocker.setenv("IOSXE_PASSWORD", "mock_pass")
+    class_mocker.setenv("IOSXE_PASSWORD", TEST_CREDENTIAL_SENTINEL)
 
     if extra_env_vars:
         for key, value in extra_env_vars.items():

--- a/tests/e2e/test_e2e_scenarios.py
+++ b/tests/e2e/test_e2e_scenarios.py
@@ -20,6 +20,7 @@ This approach:
 import logging
 import re
 import xml.etree.ElementTree as ET
+import zipfile
 
 import pytest
 
@@ -39,7 +40,7 @@ from nac_test.core.constants import (
 )
 from nac_test.robot.reporting.robot_output_parser import RobotResultParser
 from tests.conftest import assert_is_link_to
-from tests.e2e.conftest import E2EResults
+from tests.e2e.conftest import TEST_CREDENTIAL_SENTINEL, E2EResults
 from tests.e2e.html_helpers import (
     assert_combined_stats,
     assert_report_stats,
@@ -987,6 +988,44 @@ class E2ECombinedTestBase:
         assert after_closing.startswith("\n\n\n"), (
             f"Missing two blank lines after Combined Summary block.\n"
             f"Content after separator starts with: {repr(after_closing[:20])}"
+        )
+
+    # -------------------------------------------------------------------------
+    # Security Tests (#689 - Credential Exposure Prevention)
+    # -------------------------------------------------------------------------
+
+    def test_no_credentials_in_output_artifacts(self, results: E2EResults) -> None:
+        """Verify that credentials don't appear in any output artifacts.
+
+        Regression test for #689 - EnvironmentDebugPlugin was exposing env vars
+        including passwords in env.txt files within PyATS archives.
+        """
+        offending_files: list[str] = []
+
+        for file_path in results.output_dir.rglob("*"):
+            if not file_path.is_file():
+                continue
+
+            if file_path.suffix.lower() == ".zip":
+                try:
+                    with zipfile.ZipFile(file_path, "r") as zf:
+                        for name in zf.namelist():
+                            content = zf.read(name).decode("utf-8", errors="ignore")
+                            if TEST_CREDENTIAL_SENTINEL in content:
+                                offending_files.append(f"{file_path}!{name}")
+                except zipfile.BadZipFile:
+                    pass  # Not a valid zip file, skip
+            else:
+                # Check all files as text - errors="ignore" safely handles binary
+                # files by dropping undecodable bytes while preserving readable text.
+                # No try/except needed: we control output_dir, files won't disappear.
+                content = file_path.read_text(errors="ignore")
+                if TEST_CREDENTIAL_SENTINEL in content:
+                    offending_files.append(str(file_path))
+
+        assert not offending_files, (
+            "Credential sentinel found in output artifacts:\n"
+            + "\n".join(f"  - {f}" for f in offending_files)
         )
 
 


### PR DESCRIPTION
## Description

Quick fix to prevent credential exposure in PyATS result archives. The `EnvironmentDebugPlugin` was writing environment variables (including passwords) to `env.txt` files within PyATS archives.

This is an expedited fix to address the security issue before UAT. A more comprehensive PR (#697) is in progress that includes this fix along with additional cleanup for #570.

## Closes

- Fixes #689

## Related Issue(s)

- #570 (addressed in draft PR #697)
- #697 (comprehensive fix with additional refactoring)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Technical debt (internal improvements with no user-facing changes)
- [ ] Documentation update
- [ ] Chore (build process, CI, tooling, dependencies)
- [ ] Other (please describe):

## Test Framework Affected

- [x] PyATS
- [ ] Robot Framework
- [ ] Both
- [ ] N/A (not test-framework specific)

## Network as Code (NaC) Architecture Affected

- [ ] ACI (APIC)
- [ ] NDO (Nexus Dashboard Orchestrator)
- [ ] NDFC / VXLAN-EVPN (Nexus Dashboard Fabric Controller)
- [ ] Catalyst SD-WAN (SDWAN Manager / vManage)
- [ ] Catalyst Center (DNA Center)
- [ ] ISE (Identity Services Engine)
- [ ] FMC (Firepower Management Center)
- [ ] Meraki (Cloud-managed)
- [ ] NX-OS (Nexus Direct-to-Device)
- [ ] IOS-XE (Direct-to-Device)
- [ ] IOS-XR (Direct-to-Device)
- [ ] Hyperfabric
- [x] All architectures
- [ ] N/A (architecture-agnostic)

## Platform Tested

- [x] macOS (version tested: )
- [ ] Linux (distro/version tested: )

## Key Changes

- Disable `EnvironmentDebugPlugin` in PyATS subprocess runner configuration to prevent env vars from being written to archives
- Add E2E regression test that scans all output artifacts (including ZIP contents) for credential sentinel values

## Testing Done

- [x] Unit tests added/updated
- [x] Integration tests performed
- [x] Manual testing performed:
  - [x] PyATS tests executed successfully
  - [ ] Robot Framework tests executed successfully
  - [ ] D2D/SSH tests executed successfully (if applicable)
  - [x] HTML reports generated correctly
- [x] All existing tests pass (`pytest` / `pre-commit run -a`)

### Test Commands Used

without the fix in subprocess_runner, I see the new test fail:
```
E       AssertionError: Credential sentinel found in output artifacts:
E           - /private/var/folders/_f/vfw2shn13kqfdqskxs8s70qh0000gn/T/pytest-of-oboehmer/pytest-72/popen-gw13/e2e_pyats_cc0/pyats_results/api/env.txt
E           - /private/var/folders/_f/vfw2shn13kqfdqskxs8s70qh0000gn/T/pytest-of-oboehmer/pytest-72/popen-gw13/e2e_pyats_cc0/pyats_results/d2d/sd-dc-c8kv-02/env.txt
E           - /private/var/folders/_f/vfw2shn13kqfdqskxs8s70qh0000gn/T/pytest-of-oboehmer/pytest-72/popen-gw13/e2e_pyats_cc0/pyats_results/d2d/sd-dc-c8kv-01/env.txt
E       assert not ['/private/var/folders/_f/vfw2shn13kqfdqskxs8s70qh0000gn/T/pytest-of-oboehmer/pytest-72/popen-gw13/e2e_pyats_cc0/pyats...kqfdqskxs8s70qh0000gn/T/pytest-of-oboehmer/pytest-72/popen-gw13/e2e_pyats_cc0/pyats_results/d2d/sd-dc-c8kv-01/env.txt']

tests/e2e/test_e2e_scenarios.py:987: AssertionError
[...]
======================================================================== short test summary info =========================================================================
FAILED tests/e2e/test_e2e_scenarios.py::TestE2EPyatsApiOnly::test_no_credentials_in_output_artifacts - AssertionError: Credential sentinel found in output artifacts:
FAILED tests/e2e/test_e2e_scenarios.py::TestE2EVerboseWithInfo::test_no_credentials_in_output_artifacts - AssertionError: Credential sentinel found in output artifacts:
FAILED tests/e2e/test_e2e_scenarios.py::TestE2EVerbose::test_no_credentials_in_output_artifacts - AssertionError: Credential sentinel found in output artifacts:
FAILED tests/e2e/test_e2e_scenarios.py::TestE2EPyatsD2dOnly::test_no_credentials_in_output_artifacts - AssertionError: Credential sentinel found in output artifacts:
FAILED tests/e2e/test_e2e_scenarios.py::TestE2EAllFail::test_no_credentials_in_output_artifacts - AssertionError: Credential sentinel found in output artifacts:
FAILED tests/e2e/test_e2e_scenarios.py::TestE2ESuccess::test_no_credentials_in_output_artifacts - AssertionError: Credential sentinel found in output artifacts:
FAILED tests/e2e/test_e2e_scenarios.py::TestE2EMixedRelativeOutput::test_no_credentials_in_output_artifacts - AssertionError: Credential sentinel found in output artifacts:
FAILED tests/e2e/test_e2e_scenarios.py::TestE2EMixed::test_no_credentials_in_output_artifacts - AssertionError: Credential sentinel found in output artifacts:
FAILED tests/e2e/test_e2e_scenarios.py::TestE2EPyatsCc::test_no_credentials_in_output_artifacts - AssertionError: Credential sentinel found in output artifacts:
================================================== 9 failed, 644 passed, 270 skipped, 127 warnings in 92.33s (0:01:32) ===================================================
```

## Checklist

- [x] Code follows project style guidelines (`pre-commit run -a` passes)
- [x] Self-review of code completed
- [x] Code is commented where necessary (especially complex logic)
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced
- [ ] Changes work on both macOS and Linux
- [ ] CHANGELOG.md updated (if applicable)

## Screenshots (if applicable)

N/A

## Additional Notes

This is a minimal, targeted fix to mitigate the security issue quickly. PR #697 will supersede this with a more comprehensive solution that also addresses #570 (tech debt cleanup and code deduplication).