### PR TITLE
Fix robot command not found when installed via uv tool

### DIFF
--- a/nac_test/robot/pabot.py
+++ b/nac_test/robot/pabot.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2025 Daniel Schmidt
 
 import logging
-import sys
+import sysconfig
 from pathlib import Path
 
 import pabot.pabot
@@ -53,14 +53,17 @@ def run_pabot(
     include = include or []
     exclude = exclude or []
     robot_args: list[str] = []
-    # Use sys.executable to invoke robot via `python -m robot` so that pabot
+    # Resolve robot binary from the current venv's scripts directory so that pabot
     # finds the correct robot installation inside the current (possibly isolated)
     # virtual environment, rather than relying on a bare `robot` on PATH.
+    robot_path = Path(sysconfig.get_path("scripts")) / "robot"
+    if not robot_path.exists():
+        raise RuntimeError(
+            "robot executable not found - ensure robotframework is installed in the same environment as nac-test"
+        )
     pabot_args = [
         "--command",
-        sys.executable,
-        "-m",
-        "robot",
+        str(robot_path),
         "--end-command",
         "--pabotlib",
         "--pabotlibport",

--- a/tests/unit/robot/test_pabot_error_handling.py
+++ b/tests/unit/robot/test_pabot_error_handling.py
@@ -38,6 +38,52 @@ class TestRunPabotUnexpectedException:
             run_pabot(output_path)
 
 
+# --- Robot executable resolution tests ---
+
+
+class TestRunPabotRobotExecutableResolution:
+    """Test that run_pabot resolves the robot binary via sysconfig."""
+
+    @patch("nac_test.robot.pabot.pabot.pabot.main_program")
+    def test_run_pabot_resolves_robot_using_sysconfig(
+        self, mock_main_program: MagicMock, tmp_path: Path
+    ) -> None:
+        """Test that robot executable is resolved using sysconfig.get_path('scripts')."""
+        fake_scripts_dir = tmp_path / "scripts"
+        fake_scripts_dir.mkdir()
+        fake_robot_executable = fake_scripts_dir / "robot"
+        fake_robot_executable.touch()
+        mock_main_program.return_value = 0
+
+        with patch(
+            "nac_test.robot.pabot.sysconfig.get_path",
+            return_value=str(fake_scripts_dir),
+        ):
+            run_pabot(tmp_path)
+
+        call_args = mock_main_program.call_args[0][0]
+        assert "--command" in call_args
+        command_idx = call_args.index("--command")
+        assert call_args[command_idx + 1] == str(fake_robot_executable)
+
+    @patch("nac_test.robot.pabot.pabot.pabot.main_program")
+    def test_run_pabot_raises_runtime_error_when_robot_not_found(
+        self, mock_main_program: MagicMock, tmp_path: Path
+    ) -> None:
+        """Test that RuntimeError is raised when robot executable does not exist."""
+        fake_scripts_dir = tmp_path / "scripts"
+        fake_scripts_dir.mkdir()
+
+        with patch(
+            "nac_test.robot.pabot.sysconfig.get_path",
+            return_value=str(fake_scripts_dir),
+        ):
+            with pytest.raises(RuntimeError, match="robot executable not found"):
+                run_pabot(tmp_path)
+
+        mock_main_program.assert_not_called()
+
+
 class TestValidateExtraArgsDataError:
     """Test DataError handling in validate_extra_args."""
 


### PR DESCRIPTION
## Summary
- Use `sys.executable -m robot` instead of bare `robot` for pabot subprocess invocation
- Fixes "robot: command not found" when nac-test is installed in an isolated environment (e.g. `uv tool install`)

## Root cause
Pabot spawns `robot` as a subprocess by name. When nac-test is installed via `uv tool install`, the `robot` binary lives inside the isolated venv and is not on the system PATH.

## Fix
Pass `--command <python> -m robot --end-command` to pabot so it invokes robot through the current Python interpreter, which always resolves to the correct venv.