### PR TITLE
fix(deps): bump pytest-cov to 7.1 using uv override for genie conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dev = [
     "nac-test-pyats-common>=0.1.0",  # Required for integration tests
     "pre-commit>=4.3.0",
     "pytest>=8.4.2",
-    "pytest-cov~=4.1",  # Genie dependency does not support pytest-cov 6.x yet
+    "pytest-cov~=7.1",
     "pytest-httpserver>=1.1.5",
     "pytest-mock>=3.15.0",
     "pytest-xdist>=3.5.0",  # Parallel test execution
@@ -83,6 +83,13 @@ dev = [
     "types-markdown>=3.8.0.20250809",
     "types-pyyaml>=6.0.12.20250822",
     "types-requests>=2.32.0.20250809",
+]
+
+[tool.uv]
+# pysnmp==6.1.4 (pulled in by genie-libs-sdk) incorrectly declares pytest-cov<5 as a
+# runtime dependency. Override it so we can use current pytest-cov releases.
+override-dependencies = [
+    "pytest-cov>=7.1",
 ]
 
 [tool.coverage.run]

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[manifest]
+overrides = [{ name = "pytest-cov", specifier = ">=7.1" }]
+
 [[package]]
 name = "aiofiles"
 version = "25.1.0"
@@ -1878,7 +1881,7 @@ requires-dist = [
     { name = "psutil", specifier = ">=7.0.0" },
     { name = "pyats", marker = "sys_platform != 'win32'", specifier = ">=25.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.4.2" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = "~=4.1" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = "~=7.1" },
     { name = "pytest-httpserver", marker = "extra == 'dev'", specifier = ">=1.1.5" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.15.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5.0" },
@@ -2704,15 +2707,16 @@ wheels = [
 
 [[package]]
 name = "pytest-cov"
-version = "4.1.0"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/15/da3df99fd551507694a9b01f512a2f6cf1254f33601605843c3775f39460/pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6", size = 63245, upload-time = "2023-05-24T18:44:56.845Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/4b/8b78d126e275efa2379b1c2e09dc52cf70df16fc3b90613ef82531499d73/pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a", size = 21949, upload-time = "2023-05-24T18:44:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #725. Closes #716.

`pysnmp==6.1.4` (pulled in transitively by `genie-libs-sdk`) incorrectly declares `pytest-cov<5` as a runtime dependency, which has been blocking any upgrade and causing Dependabot PR #716 to fail.

Uses `[tool.uv] override-dependencies` to ignore the spurious upper bound, allowing `pytest-cov~=7.1`. `uv lock` resolves cleanly.