### PR TITLE
fix(cli): validate required args before running --diagnostic

### DIFF
--- a/nac_test/cli/diagnostic.py
+++ b/nac_test/cli/diagnostic.py
@@ -10,7 +10,6 @@ or encounters issues.
 import importlib.resources
 import shlex
 import subprocess
-import sys
 from pathlib import Path
 
 import typer
@@ -44,80 +43,27 @@ def _find_diagnostic_script() -> Path:
     return path
 
 
-def _extract_output_dir(args: list[str]) -> str | None:
-    """Extract the output directory value from command-line arguments.
-
-    Parses the argument list to find the -o/--output option value.
-    Handles all common argument syntaxes:
-    - -o value
-    - --output value
-    - --output=value
-    - -o=value
-
-    Args:
-        args: List of command-line arguments to parse.
-
-    Returns:
-        The output directory path as a string if found, None otherwise.
-        If multiple -o/--output options are present, returns the first one.
-    """
-    i = 0
-    while i < len(args):
-        arg = args[i]
-
-        # Handle --output=value or -o=value syntax
-        if arg.startswith("--output="):
-            return arg[len("--output=") :]
-        if arg.startswith("-o="):
-            return arg[len("-o=") :]
-
-        # Handle --output value or -o value syntax
-        if arg in ("-o", "--output"):
-            if i + 1 < len(args):
-                return args[i + 1]
-            return None
-
-        i += 1
-
-    return None
-
-
 def _reconstruct_command(argv: list[str]) -> str:
-    """Reconstruct the original command without the --diagnostic flag.
-
-    Takes sys.argv and removes the --diagnostic flag to create a clean
-    command string that can be passed to the diagnostic script.
-
-    Args:
-        argv: The original sys.argv list from command invocation.
-
-    Returns:
-        A shell-safe command string with --diagnostic removed,
-        suitable for passing to the diagnostic script.
-    """
-    # Filter out --diagnostic flag
+    """Reconstruct the original command without the --diagnostic flag."""
     filtered_args = [arg for arg in argv if arg != "--diagnostic"]
     return shlex.join(filtered_args)
 
 
-def diagnostic_callback(value: bool) -> None:
-    """Typer callback to handle the --diagnostic flag.
+def run_diagnostic(output_dir: Path, argv: list[str]) -> None:
+    """Run diagnostic collection and exit if requested.
 
-    When --diagnostic is specified, this callback intercepts execution,
-    runs the diagnostic collection script with the original command,
-    and exits with the script's return code.
+    This is invoked from the main CLI entrypoint *after* Typer/Click has
+    validated required args, so --diagnostic cannot bypass missing required
+    options.
 
     Args:
-        value: Boolean indicating whether --diagnostic was specified.
-            If False, returns immediately without action.
-            If True, runs diagnostic collection and exits.
+        output_dir: Parsed -o/--output value.
+        argv: The original sys.argv list.
 
     Raises:
-        typer.Exit: Always raised when value is True, with the
-            return code from the diagnostic script subprocess.
+        typer.Exit: Always raised, with the return code from the diagnostic
+            script subprocess.
     """
-    if not value:
-        return
 
     if IS_WINDOWS:
         typer.echo(
@@ -129,32 +75,13 @@ def diagnostic_callback(value: bool) -> None:
         )
         raise typer.Exit(code=EXIT_INVALID_ARGS)
 
-    # Find the diagnostic script
     script_path = _find_diagnostic_script()
-
-    # Reconstruct the original command without --diagnostic
-    command = _reconstruct_command(sys.argv)
-
-    # Extract output directory from arguments
-    output_dir = _extract_output_dir(sys.argv)
-
-    if output_dir is None:
-        typer.echo(
-            typer.style(
-                "Error: --diagnostic requires -o/--output to be specified.",
-                fg=typer.colors.RED,
-            )
-        )
-        raise typer.Exit(code=EXIT_INVALID_ARGS)
+    command = _reconstruct_command(argv)
 
     typer.echo("Running diagnostic collection...")
 
-    # Run the diagnostic script
-    # The script path and output_dir are controlled by us (bundled asset and CLI arg).
-    # The command is reconstructed from sys.argv which is user input but is passed
-    # as a single string argument to the script, not executed directly.
     result = subprocess.run(  # nosec B603 B607
-        ["bash", str(script_path), "-o", output_dir, command],
+        ["bash", str(script_path), "-o", str(output_dir), command],
         check=False,
     )
 

--- a/nac_test/cli/diagnostic.py
+++ b/nac_test/cli/diagnostic.py
@@ -11,6 +11,7 @@ import importlib.resources
 import shlex
 import subprocess
 from pathlib import Path
+from typing import NoReturn
 
 import typer
 
@@ -49,7 +50,7 @@ def _reconstruct_command(argv: list[str]) -> str:
     return shlex.join(filtered_args)
 
 
-def run_diagnostic(output_dir: Path, argv: list[str]) -> None:
+def run_diagnostic(output_dir: Path, argv: list[str]) -> NoReturn:
     """Run diagnostic collection and exit if requested.
 
     This is invoked from the main CLI entrypoint *after* Typer/Click has

--- a/nac_test/cli/diagnostic.py
+++ b/nac_test/cli/diagnostic.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import typer
 
-from nac_test.core.constants import EXIT_INVALID_ARGS
+from nac_test.core.constants import EXIT_INVALID_ARGS, IS_WINDOWS
 
 
 def _find_diagnostic_script() -> Path:
@@ -118,6 +118,16 @@ def diagnostic_callback(value: bool) -> None:
     """
     if not value:
         return
+
+    if IS_WINDOWS:
+        typer.echo(
+            typer.style(
+                "Error: --diagnostic is supported only on Linux and macOS (requires bash).",
+                fg=typer.colors.RED,
+            ),
+            err=True,
+        )
+        raise typer.Exit(code=EXIT_INVALID_ARGS)
 
     # Find the diagnostic script
     script_path = _find_diagnostic_script()

--- a/nac_test/cli/diagnostic.py
+++ b/nac_test/cli/diagnostic.py
@@ -51,7 +51,8 @@ def _reconstruct_command(argv: list[str]) -> str:
 
 
 def run_diagnostic(output_dir: Path, argv: list[str]) -> NoReturn:
-    """Run diagnostic collection and exit if requested.
+    """Run diagnostic collection shell script, wrapping nac-test
+    execution with pre/post environment and log collection.
 
     This is invoked from the main CLI entrypoint *after* Typer/Click has
     validated required args, so --diagnostic cannot bypass missing required

--- a/nac_test/cli/diagnostic.py
+++ b/nac_test/cli/diagnostic.py
@@ -51,9 +51,9 @@ def _reconstruct_command(argv: list[str]) -> str:
 
 
 def run_diagnostic(output_dir: Path, argv: list[str]) -> NoReturn:
-    """Run diagnostic collection shell script, wrapping nac-test
-    execution with pre/post environment and log collection.
+    """Run the diagnostic collection shell script.
 
+    Wraps nac-test execution with pre/post environment and log collection.
     This is invoked from the main CLI entrypoint *after* Typer/Click has
     validated required args, so --diagnostic cannot bypass missing required
     options.

--- a/nac_test/cli/diagnostic.py
+++ b/nac_test/cli/diagnostic.py
@@ -45,7 +45,14 @@ def _find_diagnostic_script() -> Path:
 
 
 def _reconstruct_command(argv: list[str]) -> str:
-    """Reconstruct the original command without the --diagnostic flag."""
+    """Reconstruct the original command without the --diagnostic flag.
+
+    Args:
+        argv: The original sys.argv list (may include --diagnostic).
+
+    Returns:
+        A shell-safe command string with --diagnostic removed.
+    """
     filtered_args = [arg for arg in argv if arg != "--diagnostic"]
     return shlex.join(filtered_args)
 

--- a/nac_test/cli/main.py
+++ b/nac_test/cli/main.py
@@ -4,6 +4,7 @@
 """CLI entry point for nac-test."""
 
 import logging
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Annotated
@@ -14,7 +15,7 @@ from rich.panel import Panel
 from robot.errors import DataError
 
 import nac_test
-from nac_test.cli.diagnostic import diagnostic_callback
+from nac_test.cli.diagnostic import run_diagnostic
 from nac_test.cli.ui import display_aci_defaults_banner
 from nac_test.cli.validators import validate_aci_defaults, validate_extra_args
 from nac_test.combined_orchestrator import CombinedOrchestrator
@@ -37,6 +38,7 @@ from nac_test.utils.platform import check_and_exit_if_unsupported_macos_python
 # Pretty exceptions are verbose but helpful for debugging.
 # Enable them when NAC_TEST_DEBUG=true, disable for cleaner output otherwise.
 app = typer.Typer(add_completion=False, pretty_exceptions_enable=DEBUG_MODE)
+
 
 logger = logging.getLogger(__name__)
 
@@ -270,8 +272,6 @@ Diagnostic = Annotated[
     bool,
     typer.Option(
         "--diagnostic",
-        callback=diagnostic_callback,
-        is_eager=True,
         help="Wrap execution with diagnostic collection (Linux/macOS only). Produces a zip with system info, logs, and artifacts.",
     ),
 ]
@@ -320,8 +320,8 @@ def main(
     testbed: Testbed = None,
     loglevel: LoglevelOption = None,
     verbosity: DeprecatedVerbosity = None,
-    version: Version = False,  # noqa: ARG001
-    diagnostic: Diagnostic = False,  # noqa: ARG001
+    version: Version = False,
+    diagnostic: Diagnostic = False,
     verbose: Verbose = False,
     merged_data_filename: MergedDataFilename = "merged_data_model_test_variables.yaml",
 ) -> None:
@@ -333,6 +333,9 @@ def main(
     files/directories, and options controlled by nac-test (like --include, --exclude)
     are not supported and will result in an error.
     """
+
+    if diagnostic:
+        run_diagnostic(output, argv=[ctx.command_path, *sys.argv[1:]])
 
     # Handle deprecated --verbosity option
     if verbosity is not None:

--- a/nac_test/cli/main.py
+++ b/nac_test/cli/main.py
@@ -335,7 +335,7 @@ def main(
     """
 
     if diagnostic:
-        run_diagnostic(output, argv=[ctx.command_path, *sys.argv[1:]])
+        run_diagnostic(output, argv=sys.argv)
 
     # Handle deprecated --verbosity option
     if verbosity is not None:

--- a/nac_test/cli/main.py
+++ b/nac_test/cli/main.py
@@ -272,7 +272,7 @@ Diagnostic = Annotated[
         "--diagnostic",
         callback=diagnostic_callback,
         is_eager=True,
-        help="Wrap execution with diagnostic collection. Produces a zip with system info, logs, and artifacts.",
+        help="Wrap execution with diagnostic collection (Linux/macOS only). Produces a zip with system info, logs, and artifacts.",
     ),
 ]
 

--- a/nac_test/support/nac-test-diagnostic.sh
+++ b/nac_test/support/nac-test-diagnostic.sh
@@ -539,7 +539,7 @@ echo '=== NaC-related packages ==='
 "
 
 collect "034_pyats_version" "
-python -c 'import pyats; print(f\"PyATS version: {pyats.__version__}\")' 2>&1 || echo 'PyATS not installed or import failed'
+pyats version check 2>&1 || echo 'pyats CLI not available'
 "
 
 ###############################################################################
@@ -657,6 +657,7 @@ NAC_TEST_START=$(date +%s)
 
 # Execute the user's nac-test command
 log "${YELLOW}Starting nac-test execution...${NC}"
+log "Output is being captured in $DIAG_DIR/100_nac_test_execution.txt"
 log ""
 
 {

--- a/nac_test/support/nac-test-diagnostic.sh
+++ b/nac_test/support/nac-test-diagnostic.sh
@@ -758,14 +758,16 @@ echo '   review them before sharing if you have concerns about credential exposu
         log "  ${YELLOW}⚠️  WARNING: Archives may contain logs with credentials - review before sharing${NC}"
     fi
 
-    # Collect Robot Framework outputs (if running --robot)
+    # Collect Robot Framework outputs
+    ROBOT_FILES=$(find "$OUTPUT_DIR/robot_results" \( -name 'output.xml' -o -name 'log.html' -o -name 'report.html' \) -mmin -60 2>/dev/null)
+
     collect "120_robot_outputs" "
 echo 'Robot Framework output files:'
-find '$OUTPUT_DIR' -name 'output.xml' -o -name 'log.html' -o -name 'report.html' 2>/dev/null | head -20
+echo \"$ROBOT_FILES\" | head -20
 "
 
     ROBOT_COUNT=0
-    for robot_file in $(find "$OUTPUT_DIR" \( -name 'output.xml' -o -name 'log.html' -o -name 'report.html' \) -mmin -60 2>/dev/null); do
+    for robot_file in $ROBOT_FILES; do
         cp "$robot_file" "$DIAG_DIR/" 2>/dev/null && ROBOT_COUNT=$((ROBOT_COUNT + 1))
     done
     if [ "$ROBOT_COUNT" -gt 0 ]; then

--- a/nac_test/support/nac-test-diagnostic.sh
+++ b/nac_test/support/nac-test-diagnostic.sh
@@ -371,7 +371,7 @@ collect() {
 log ""
 log "${CYAN}╔══════════════════════════════════════════════════════════════════╗${NC}"
 log "${CYAN}║        NAC-Test Diagnostic Collection v5.0                       ║${NC}"
-log "${CYAN}║              Architecture-Agnostic Edition                        ║${NC}"
+log "${CYAN}║              Architecture-Agnostic Edition                       ║${NC}"
 log "${CYAN}╚══════════════════════════════════════════════════════════════════╝${NC}"
 log ""
 log "${GREEN}=== NAC-Test Diagnostic Collection v5.0 ===${NC}"
@@ -682,7 +682,6 @@ log ""
     echo "Exit code: $NAC_TEST_EXIT"
 } > "$DIAG_DIR/100_nac_test_execution.txt" 2>&1
 
-NAC_TEST_EXIT=${PIPESTATUS[0]}
 NAC_TEST_END=$(date +%s)
 NAC_TEST_DURATION=$((NAC_TEST_END - NAC_TEST_START))
 
@@ -870,7 +869,7 @@ zip -r "$ZIP_NAME" "$DIAG_DIR" > /dev/null
 
 log ""
 log "${GREEN}╔══════════════════════════════════════════════════════════════════╗${NC}"
-log "${GREEN}║              DIAGNOSTIC COLLECTION COMPLETE                       ║${NC}"
+log "${GREEN}║              DIAGNOSTIC COLLECTION COMPLETE                      ║${NC}"
 log "${GREEN}╚══════════════════════════════════════════════════════════════════╝${NC}"
 log ""
 log "Archive: ${GREEN}$ZIP_NAME${NC}"

--- a/nac_test/support/nac-test-diagnostic.sh
+++ b/nac_test/support/nac-test-diagnostic.sh
@@ -865,7 +865,10 @@ done
 ZIP_NAME="${DIAG_DIR}.zip"
 log ""
 log "Creating archive: $ZIP_NAME"
-zip -r "$ZIP_NAME" "$DIAG_DIR" > /dev/null
+(
+    cd "$(dirname "$DIAG_DIR")" || exit 1
+    zip -r "$(basename "$ZIP_NAME")" "$(basename "$DIAG_DIR")" > /dev/null
+)
 
 log ""
 log "${GREEN}╔══════════════════════════════════════════════════════════════════╗${NC}"

--- a/nac_test/support/nac-test-diagnostic.sh
+++ b/nac_test/support/nac-test-diagnostic.sh
@@ -170,6 +170,25 @@ detect_architecture() {
 DETECTED_ARCH=$(detect_architecture)
 
 ###############################################################################
+# REQUIREMENTS PREFLIGHT
+###############################################################################
+
+if ! command -v zip >/dev/null 2>&1; then
+    echo ""
+    echo -e "${RED}zip command not found${NC}"
+    echo -e "${YELLOW}Install it and re-run diagnostics:${NC}"
+    if $IS_MACOS; then
+        echo "  brew install zip"
+    else
+        echo "  sudo apt-get update && sudo apt-get install -y zip"
+        echo "  # or: sudo dnf install -y zip"
+        echo "  # or: sudo yum install -y zip"
+    fi
+    echo ""
+    exit 1
+fi
+
+###############################################################################
 # SETUP DIAGNOSTIC DIRECTORY
 ###############################################################################
 

--- a/nac_test/support/nac-test-diagnostic.sh
+++ b/nac_test/support/nac-test-diagnostic.sh
@@ -88,8 +88,10 @@ done
 
 shift $((OPTIND-1))
 
-# The remaining argument is the nac-test command
-NAC_TEST_COMMAND="$*"
+# The remaining positional argument must be a single shell command string
+# (quoted by the caller). We treat it as an opaque command for `bash -c`.
+[ $# -eq 1 ] || { echo -e "${RED}Error: nac-test command must be passed as a single quoted argument${NC}"; exit 1; }
+NAC_TEST_COMMAND="$1"
 
 # Validate required arguments
 if [ -z "$OUTPUT_DIR" ]; then
@@ -657,7 +659,8 @@ NAC_TEST_START=$(date +%s)
 
 # Execute the user's nac-test command
 log "${YELLOW}Starting nac-test execution...${NC}"
-log "Output is being captured in $DIAG_DIR/100_nac_test_execution.txt"
+log "Note: nac-test output is not shown on screen."
+log "  Saved to: $DIAG_DIR/100_nac_test_execution.txt"
 log ""
 
 {

--- a/tests/unit/cli/test_diagnostic.py
+++ b/tests/unit/cli/test_diagnostic.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2025 Daniel Schmidt
 """Unit tests for the diagnostic CLI module."""
 
+import shlex
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -16,33 +17,56 @@ from nac_test.cli.diagnostic import (
 from nac_test.core.constants import EXIT_INVALID_ARGS
 
 
+@pytest.fixture()
+def base_argv() -> list[str]:
+    return [
+        "nac-test",
+        "-d",
+        "./data",
+        "-t",
+        "./tests",
+        "-o",
+        "./out",
+    ]
+
+
+@pytest.fixture()
+def base_argv_with_spaces() -> list[str]:
+    return [
+        "nac-test",
+        "-d",
+        "./data with spaces",
+        "-t",
+        "./tests",
+        "-o",
+        "./out",
+    ]
+
+
 class TestReconstructCommand:
     """Tests for _reconstruct_command function."""
 
-    def test_removes_diagnostic_flag(self) -> None:
-        """Test that --diagnostic is removed from command."""
-        argv = ["nac-test", "-d", "./data", "--diagnostic", "-o", "./out"]
+    def test_removes_diagnostic_flag(self, base_argv: list[str]) -> None:
+        """Test that --diagnostic is removed from the reconstructed argv."""
+        argv = [*base_argv, "--diagnostic"]
         result = _reconstruct_command(argv)
-        assert "--diagnostic" not in result
-        assert "nac-test" in result
-        assert "-d" in result
 
-    def test_preserves_other_args(self) -> None:
-        """Test that other arguments are preserved."""
-        argv = ["nac-test", "-d", "./data", "-t", "./tests", "--diagnostic"]
-        result = _reconstruct_command(argv)
-        # Verify key args are present (don't test exact shlex output)
-        assert "-d" in result
-        assert "-t" in result
-        assert "./data" in result
-        assert "./tests" in result
+        reconstructed = shlex.split(result)
+        assert reconstructed == base_argv
 
-    def test_handles_no_diagnostic_flag(self) -> None:
+    def test_handles_no_diagnostic_flag(self, base_argv: list[str]) -> None:
         """Test command reconstruction when --diagnostic isn't present."""
-        argv = ["nac-test", "-d", "./data"]
-        result = _reconstruct_command(argv)
-        assert "nac-test" in result
-        assert "-d" in result
+        result = _reconstruct_command(base_argv)
+
+        reconstructed = shlex.split(result)
+        assert reconstructed == base_argv
+
+    def test_quotes_args_with_spaces(self, base_argv_with_spaces: list[str]) -> None:
+        """Test that args with spaces are preserved via shell-safe quoting."""
+        result = _reconstruct_command(base_argv_with_spaces)
+
+        reconstructed = shlex.split(result)
+        assert reconstructed == base_argv_with_spaces
 
 
 class TestFindDiagnosticScript:
@@ -61,14 +85,14 @@ class TestFindDiagnosticScript:
 
 
 class TestRunDiagnostic:
-    def test_windows_errors_without_running_script(self) -> None:
+    def test_windows_errors_without_running_script(self, base_argv: list[str]) -> None:
         with (
             patch("nac_test.cli.diagnostic.IS_WINDOWS", True),
             patch("nac_test.cli.diagnostic.subprocess.run") as mock_run,
             patch("nac_test.cli.diagnostic.typer.echo") as mock_echo,
         ):
             with pytest.raises(typer.Exit) as exc_info:
-                run_diagnostic(Path("/tmp/out"), argv=["nac-test", "--diagnostic"])
+                run_diagnostic(Path("./out"), argv=[*base_argv, "--diagnostic"])
 
             assert exc_info.value.exit_code == EXIT_INVALID_ARGS  # type: ignore[unreachable]
             mock_run.assert_not_called()
@@ -80,7 +104,9 @@ class TestRunDiagnostic:
             assert mock_echo.call_args.kwargs["err"] is True
 
     @patch("nac_test.cli.diagnostic.subprocess.run")
-    def test_propagates_script_exit_code(self, mock_run: MagicMock) -> None:
+    def test_propagates_script_exit_code(
+        self, mock_run: MagicMock, base_argv: list[str]
+    ) -> None:
         mock_run.return_value = MagicMock(returncode=42)
 
         with (
@@ -88,10 +114,7 @@ class TestRunDiagnostic:
             patch("nac_test.cli.diagnostic.typer.echo"),
         ):
             with pytest.raises(typer.Exit) as exc_info:
-                run_diagnostic(
-                    Path("/tmp/out"),
-                    argv=["nac-test", "-o", "/tmp/out", "--diagnostic"],
-                )
+                run_diagnostic(Path("./out"), argv=[*base_argv, "--diagnostic"])
 
             assert exc_info.value.exit_code == 42  # type: ignore[unreachable]
             mock_run.assert_called_once()

--- a/tests/unit/cli/test_diagnostic.py
+++ b/tests/unit/cli/test_diagnostic.py
@@ -70,7 +70,7 @@ class TestRunDiagnostic:
             with pytest.raises(typer.Exit) as exc_info:
                 run_diagnostic(Path("/tmp/out"), argv=["nac-test", "--diagnostic"])
 
-            assert exc_info.value.exit_code == EXIT_INVALID_ARGS
+            assert exc_info.value.exit_code == EXIT_INVALID_ARGS  # type: ignore[unreachable]
             mock_run.assert_not_called()
             mock_echo.assert_called_once()
             assert (
@@ -93,5 +93,5 @@ class TestRunDiagnostic:
                     argv=["nac-test", "-o", "/tmp/out", "--diagnostic"],
                 )
 
-            assert exc_info.value.exit_code == 42
+            assert exc_info.value.exit_code == 42  # type: ignore[unreachable]
             mock_run.assert_called_once()

--- a/tests/unit/cli/test_diagnostic.py
+++ b/tests/unit/cli/test_diagnostic.py
@@ -154,3 +154,28 @@ class TestDiagnosticCallback:
                 diagnostic_callback(True)
 
             assert exc_info.value.exit_code == 42
+
+    @patch("nac_test.cli.diagnostic.subprocess.run")
+    def test_windows_errors_without_running_script(self, mock_run: MagicMock) -> None:
+        """Test that --diagnostic hard-errors on Windows without running subprocess."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        with (
+            patch("nac_test.cli.diagnostic.IS_WINDOWS", True),
+            patch(
+                "nac_test.cli.diagnostic.sys.argv",
+                ["nac-test", "-d", "./data", "-o", "./output", "--diagnostic"],
+            ),
+            patch("nac_test.cli.diagnostic.typer.echo") as mock_echo,
+        ):
+            with pytest.raises(typer.Exit) as exc_info:
+                diagnostic_callback(True)
+
+            assert exc_info.value.exit_code == EXIT_INVALID_ARGS
+            mock_run.assert_not_called()
+            mock_echo.assert_called_once()
+            assert (
+                "--diagnostic is supported only on Linux and macOS"
+                in mock_echo.call_args.args[0]
+            )
+            assert mock_echo.call_args.kwargs["err"] is True

--- a/tests/unit/cli/test_diagnostic.py
+++ b/tests/unit/cli/test_diagnostic.py
@@ -85,6 +85,8 @@ class TestFindDiagnosticScript:
 
 
 class TestRunDiagnostic:
+    """Tests for run_diagnostic function."""
+
     def test_windows_errors_without_running_script(self, base_argv: list[str]) -> None:
         with (
             patch("nac_test.cli.diagnostic.IS_WINDOWS", True),

--- a/tests/unit/cli/test_diagnostic.py
+++ b/tests/unit/cli/test_diagnostic.py
@@ -118,3 +118,7 @@ class TestRunDiagnostic:
 
             assert exc_info.value.exit_code == 42  # type: ignore[unreachable]
             mock_run.assert_called_once()
+            call_args = mock_run.call_args[0][0]
+            assert call_args[0] == "bash"
+            assert "nac-test-diagnostic.sh" in call_args[1]
+            assert call_args[2:4] == ["-o", str(Path("./out"))]

--- a/tests/unit/cli/test_diagnostic.py
+++ b/tests/unit/cli/test_diagnostic.py
@@ -9,58 +9,11 @@ import pytest
 import typer
 
 from nac_test.cli.diagnostic import (
-    _extract_output_dir,
     _find_diagnostic_script,
     _reconstruct_command,
-    diagnostic_callback,
+    run_diagnostic,
 )
 from nac_test.core.constants import EXIT_INVALID_ARGS
-
-
-class TestExtractOutputDir:
-    """Tests for _extract_output_dir function."""
-
-    def test_short_flag_with_space(self) -> None:
-        """Test extraction with -o value syntax."""
-        args = ["-d", "./data", "-o", "./output", "-t", "./tests"]
-        result = _extract_output_dir(args)
-        assert result == "./output"
-
-    def test_long_flag_with_space(self) -> None:
-        """Test extraction with --output value syntax."""
-        args = ["-d", "./data", "--output", "./my-output", "-t", "./tests"]
-        result = _extract_output_dir(args)
-        assert result == "./my-output"
-
-    def test_long_flag_with_equals(self) -> None:
-        """Test extraction with --output=value syntax."""
-        args = ["-d", "./data", "--output=./results", "-t", "./tests"]
-        result = _extract_output_dir(args)
-        assert result == "./results"
-
-    def test_short_flag_with_equals(self) -> None:
-        """Test extraction with -o=value syntax."""
-        args = ["-d", "./data", "-o=./results", "-t", "./tests"]
-        result = _extract_output_dir(args)
-        assert result == "./results"
-
-    def test_missing_output_returns_none(self) -> None:
-        """Test that missing -o/--output returns None."""
-        args = ["-d", "./data", "-t", "./tests"]
-        result = _extract_output_dir(args)
-        assert result is None
-
-    def test_output_at_end_of_args(self) -> None:
-        """Test that -o at end without value returns None."""
-        args = ["-d", "./data", "-o"]
-        result = _extract_output_dir(args)
-        assert result is None
-
-    def test_returns_first_occurrence(self) -> None:
-        """Test that first -o occurrence is returned when multiple present."""
-        args = ["-o", "first", "-o", "second"]
-        result = _extract_output_dir(args)
-        assert result == "first"
 
 
 class TestReconstructCommand:
@@ -107,69 +60,15 @@ class TestFindDiagnosticScript:
         assert result.name == "nac-test-diagnostic.sh"
 
 
-class TestDiagnosticCallback:
-    """Tests for diagnostic_callback function."""
-
-    def test_false_returns_immediately(self) -> None:
-        """Test that False value returns without action."""
-        # This should not raise or call subprocess - just returns None
-        diagnostic_callback(False)  # Should complete without raising
-
-    def test_true_without_output_dir_raises_exit(self) -> None:
-        """Test that True without -o/--output raises Exit with code 1."""
-        with patch("nac_test.cli.diagnostic.sys.argv", ["nac-test", "-d", "./data"]):
-            with pytest.raises(typer.Exit) as exc_info:
-                diagnostic_callback(True)
-            assert exc_info.value.exit_code == EXIT_INVALID_ARGS
-
-    @patch("nac_test.cli.diagnostic.subprocess.run")
-    def test_true_with_output_dir_runs_script(self, mock_run: MagicMock) -> None:
-        """Test that True with valid args runs subprocess and exits."""
-        mock_run.return_value = MagicMock(returncode=0)
-
-        with patch(
-            "nac_test.cli.diagnostic.sys.argv",
-            ["nac-test", "-d", "./data", "-o", "./output", "--diagnostic"],
-        ):
-            with pytest.raises(typer.Exit) as exc_info:
-                diagnostic_callback(True)
-
-            assert exc_info.value.exit_code == 0
-            mock_run.assert_called_once()
-            # Verify bash is called with script path
-            call_args = mock_run.call_args[0][0]
-            assert call_args[0] == "bash"
-            assert "nac-test-diagnostic.sh" in call_args[1]
-
-    @patch("nac_test.cli.diagnostic.subprocess.run")
-    def test_propagates_script_exit_code(self, mock_run: MagicMock) -> None:
-        """Test that subprocess exit code is propagated."""
-        mock_run.return_value = MagicMock(returncode=42)
-
-        with patch(
-            "nac_test.cli.diagnostic.sys.argv",
-            ["nac-test", "-d", "./data", "-o", "./output", "--diagnostic"],
-        ):
-            with pytest.raises(typer.Exit) as exc_info:
-                diagnostic_callback(True)
-
-            assert exc_info.value.exit_code == 42
-
-    @patch("nac_test.cli.diagnostic.subprocess.run")
-    def test_windows_errors_without_running_script(self, mock_run: MagicMock) -> None:
-        """Test that --diagnostic hard-errors on Windows without running subprocess."""
-        mock_run.return_value = MagicMock(returncode=0)
-
+class TestRunDiagnostic:
+    def test_windows_errors_without_running_script(self) -> None:
         with (
             patch("nac_test.cli.diagnostic.IS_WINDOWS", True),
-            patch(
-                "nac_test.cli.diagnostic.sys.argv",
-                ["nac-test", "-d", "./data", "-o", "./output", "--diagnostic"],
-            ),
+            patch("nac_test.cli.diagnostic.subprocess.run") as mock_run,
             patch("nac_test.cli.diagnostic.typer.echo") as mock_echo,
         ):
             with pytest.raises(typer.Exit) as exc_info:
-                diagnostic_callback(True)
+                run_diagnostic(Path("/tmp/out"), argv=["nac-test", "--diagnostic"])
 
             assert exc_info.value.exit_code == EXIT_INVALID_ARGS
             mock_run.assert_not_called()
@@ -179,3 +78,20 @@ class TestDiagnosticCallback:
                 in mock_echo.call_args.args[0]
             )
             assert mock_echo.call_args.kwargs["err"] is True
+
+    @patch("nac_test.cli.diagnostic.subprocess.run")
+    def test_propagates_script_exit_code(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=42)
+
+        with (
+            patch("nac_test.cli.diagnostic.IS_WINDOWS", False),
+            patch("nac_test.cli.diagnostic.typer.echo"),
+        ):
+            with pytest.raises(typer.Exit) as exc_info:
+                run_diagnostic(
+                    Path("/tmp/out"),
+                    argv=["nac-test", "-o", "/tmp/out", "--diagnostic"],
+                )
+
+            assert exc_info.value.exit_code == 42
+            mock_run.assert_called_once()


### PR DESCRIPTION
## Description

This PR improves `--diagnostic` behavior and the bundled diagnostic collection script to make diagnostics safer, more accurate, and easier to consume.

### CLI `--diagnostic` behavior (Fixes #740)
- Move `--diagnostic` handling out of the Typer callback and into [`nac_test/cli/main.py`](nac_test/cli/main.py) so required args are validated by Typer/Click before diagnostics run.
- Introduce [`run_diagnostic(...)`](nac_test/cli/diagnostic.py) (annotated `NoReturn`) that runs the diagnostic script and exits with the script’s return code.
- Reject Windows early for `--diagnostic`.

### Diagnostic script improvements (Fixes #664 + follow-ups)
- Fail fast with a clear message when `zip` command is missing (observed on WSL2 environment)
- Fix wrapped command exit code reporting (avoid incorrect `PIPESTATUS` usage).
- Create zip archives with **relative paths** (avoid embedding full `/var/...` prefixes in the archive contents).
- Use `pyats version check` instead of `pyats.__version__` for reliable version capture.
- Expect the wrapped nac-test command as a **single quoted argument** (`$1`) and enforce the contract.
- Update Robot Framework artifact collection to use `$OUTPUT_DIR/robot_results`, and collect robot outputs via a single `find` pass.
- Clarify log messaging around where nac-test output is captured.

### Tests
- Update `tests/unit/cli/test_diagnostic.py` to match the new `run_diagnostic` entrypoint.
- Tighten `_reconstruct_command` coverage with strict `shlex.join`/`shlex.split` round-trip assertions.
- Add fixtures for a canonical argv including required options and a variant containing spaces.
- Silence a mypy false-positive around `NoReturn` in `pytest.raises`.

## Closes

- Fixes #740
- Fixes #664

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring / Technical debt
- [ ] Documentation update
- [ ] Chore
- [ ] Other (please describe):

## Test Framework Affected

- [ ] PyATS
- [ ] Robot Framework
- [ ] Both
- [x] N/A (not test-framework specific)

## NaC Architecture Affected

- [x] N/A (architecture-agnostic)

## Platform Tested

- [x] macOS (local dev)
- [ ] Linux (distro/version tested: )

## Key Changes

- Validate required CLI args before running diagnostics (`--diagnostic` no longer bypasses missing options).
- Ensure diagnostic summary reports the wrapped command’s real exit code.
- Improve diagnostic archive portability (relative zip paths) and robustness (zip preflight, stricter command arg handling, PyATS version capture).
- Adjust artifact collection paths for Robot Framework.

## Testing Done

- [x] Unit tests added/updated
- [ ] Integration tests performed
- [ ] Manual testing performed:
  - [ ] PyATS tests executed successfully
  - [ ] Robot Framework tests executed successfully
  - [ ] HTML reports generated correctly
- [x] All existing tests pass (`pytest` / `pre-commit run -a`)

### Test Commands Used

```bash
python -m pytest -q
pre-commit run -a
```

## Additional Notes

- Diagnostic command is passed to the script as a single shell-safe string (from `shlex.join`), and the script enforces that it receives exactly one command argument.
- Robot outputs are now expected under `$OUTPUT_DIR/robot_results`.