### PR TITLE
fix(gha): handle multiline commit messages in notification env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,8 +212,15 @@ jobs:
           # messages, 200 chars for PR titles are generous practical limits)
           COMMIT_MSG=$(echo "$RAW_COMMIT_MSG" | head -c 500)
           PR_TITLE=$(echo "$RAW_PR_TITLE" | head -c 200)
-          echo "SAFE_COMMIT_MSG=${COMMIT_MSG}" >> "$GITHUB_ENV"
-          echo "SAFE_PR_TITLE=${PR_TITLE}" >> "$GITHUB_ENV"
+
+          {
+            echo "SAFE_COMMIT_MSG<<'EOF'"
+            echo "$COMMIT_MSG"
+            echo "EOF"
+            echo "SAFE_PR_TITLE<<'EOF'"
+            echo "$PR_TITLE"
+            echo "EOF"
+          } >> "$GITHUB_ENV"
 
       # Using direct curl to Webex API instead of a GitHub Action because:
       # - qsnyder/action-wxt is unmaintained (last commit 2022, no releases)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,10 +214,10 @@ jobs:
           PR_TITLE=$(echo "$RAW_PR_TITLE" | head -c 200)
 
           {
-            echo "SAFE_COMMIT_MSG<<'EOF'"
+            echo "SAFE_COMMIT_MSG<<EOF"
             echo "$COMMIT_MSG"
             echo "EOF"
-            echo "SAFE_PR_TITLE<<'EOF'"
+            echo "SAFE_PR_TITLE<<EOF"
             echo "$PR_TITLE"
             echo "EOF"
           } >> "$GITHUB_ENV"


### PR DESCRIPTION
## Description

Fix the GitHub Actions notification job failing when `github.event.head_commit.message` contains newlines (commit bodies). The workflow wrote multi-line values to `$GITHUB_ENV` using `KEY=VALUE`, which breaks the env file-command parser.

## Closes

- Fixes #742

## Related Issue(s)

-

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Technical debt (internal improvements with no user-facing changes)
- [ ] Documentation update
- [ ] Chore (build process, CI, tooling, dependencies)
- [ ] Other (please describe):

## Test Framework Affected

- [ ] PyATS
- [ ] Robot Framework
- [ ] Both
- [x] N/A (not test-framework specific)

## Network as Code (NaC) Architecture Affected

- [ ] ACI (APIC)
- [ ] NDO (Nexus Dashboard Orchestrator)
- [ ] NDFC / VXLAN-EVPN (Nexus Dashboard Fabric Controller)
- [ ] Catalyst SD-WAN (SDWAN Manager / vManage)
- [ ] Catalyst Center (DNA Center)
- [ ] ISE (Identity Services Engine)
- [ ] FMC (Firepower Management Center)
- [ ] Meraki (Cloud-managed)
- [ ] NX-OS (Nexus Direct-to-Device)
- [ ] IOS-XE (Direct-to-Device)
- [ ] IOS-XR (Direct-to-Device)
- [ ] Hyperfabric
- [ ] All architectures
- [x] N/A (architecture-agnostic)

## Platform Tested

- [ ] macOS (version tested: )
- [x] Linux (distro/version tested: GitHub Actions ubuntu-latest)

## Key Changes

- Write `SAFE_COMMIT_MSG` and `SAFE_PR_TITLE` into `$GITHUB_ENV` using the multiline heredoc format (`NAME<<EOF ... EOF`), which safely supports newline characters.

## Testing Done

- [x] All existing tests pass (`pytest`)

### Test Commands Used

```bash
python -m pytest -q
```

## Checklist

- [x] Code follows project style guidelines (`pre-commit run -a` passes)
- [x] Self-review of code completed
- [x] No new warnings introduced
- [x] Changes work on both macOS and Linux

## Additional Notes

Failing run example: https://github.com/netascode/nac-test/actions/runs/24121578862/job/70377166489