### PR TITLE
Chore/relax aiofiles pin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
         exclude: 'tests/fixtures/|tests/integration/fixtures/|tests/e2e/fixtures/'
         additional_dependencies:
           - types-PyYAML>=6.0.12.20250822
-          - types-aiofiles>=24.1.0.20250822
+          - types-aiofiles>=23.2.0.20240623
           - types-markdown>=3.8.0.20250809
           - types-requests>=2.32.0.20250809
   - repo: https://github.com/PyCQA/bandit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "genie>=25.5 ; sys_platform != 'win32'",
     "psutil>=7.0.0",
     "httpx~=0.28",
-    "aiofiles>=24.1",
+    "aiofiles>=23.2.1",     # radit-client still uses <24.0, so relax to avoid conflicts
     "colorama>=0.4.6",
     "markdown>=3.8.2",
     "typing_extensions>=4.0; python_version < '3.11'",
@@ -79,7 +79,7 @@ dev = [
     "pytest-mock>=3.15.0",
     "pytest-xdist>=3.5.0",  # Parallel test execution
     "ruff>=0.12.12",
-    "types-aiofiles>=24.1.0.20250822",
+    "types-aiofiles>=23.2.0.20240623",
     "types-markdown>=3.8.0.20250809",
     "types-pyyaml>=6.0.12.20250822",
     "types-requests>=2.32.0.20250809",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "genie>=25.5 ; sys_platform != 'win32'",
     "psutil>=7.0.0",
     "httpx~=0.28",
-    "aiofiles>=23.2.1",     # radit-client still uses <24.0, so relax to avoid conflicts
+    "aiofiles>=23.2.1",  # radkit-client still uses <24.0, so relax to avoid conflicts
     "colorama>=0.4.6",
     "markdown>=3.8.2",
     "typing_extensions>=4.0; python_version < '3.11'",

--- a/uv.lock
+++ b/uv.lock
@@ -1806,7 +1806,7 @@ wheels = [
 
 [[package]]
 name = "nac-test"
-version = "2.0.0b2"
+version = "2.0.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -1859,7 +1859,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles", specifier = ">=24.1" },
+    { name = "aiofiles", specifier = ">=23.2.1" },
     { name = "ansible-core", marker = "extra == 'dev'", specifier = ">=2.17.6" },
     { name = "asyncssh", specifier = ">=2.22.0" },
     { name = "bandit", extras = ["toml"], marker = "extra == 'dev'", specifier = ">=1.8.6" },
@@ -1867,7 +1867,7 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.0.0" },
     { name = "flask", marker = "extra == 'dev'", specifier = ">=3.1" },
     { name = "genie", marker = "sys_platform != 'win32'", specifier = ">=25.5" },
-    { name = "httpx", specifier = ">=0.28" },
+    { name = "httpx", specifier = "~=0.28" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jmespath", specifier = ">=1.0.1" },
     { name = "jsonpath-ng", specifier = "!=1.8.0" },
@@ -1894,7 +1894,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.12.12" },
     { name = "scrapli-netconf", specifier = ">=2026.1.12" },
     { name = "typer", specifier = ">=0.17.4" },
-    { name = "types-aiofiles", marker = "extra == 'dev'", specifier = ">=24.1.0.20250822" },
+    { name = "types-aiofiles", marker = "extra == 'dev'", specifier = ">=23.2.0.20240623" },
     { name = "types-markdown", marker = "extra == 'dev'", specifier = ">=3.8.0.20250809" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20250822" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.0.20250809" },


### PR DESCRIPTION

Relax dependency for `aiofiles` to `>=23.2.1` in order to avoid conflicts for concurrent nac-test and radkit-client installation.

