### PR TITLE
fix(gha): push to explicit branch ref in dependabot lock-file update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add uv.lock
             git commit -m "chore: update uv.lock [dependabot skip]"
-            git push
+            git push origin HEAD:refs/heads/${{ github.head_ref }}
           fi
 
       - name: Check License Headers

--- a/uv.lock
+++ b/uv.lock
@@ -1806,7 +1806,7 @@ wheels = [
 
 [[package]]
 name = "nac-test"
-version = "2.0.0b2"
+version = "2.0.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -1867,7 +1867,7 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.0.0" },
     { name = "flask", marker = "extra == 'dev'", specifier = ">=3.1" },
     { name = "genie", marker = "sys_platform != 'win32'", specifier = ">=25.5" },
-    { name = "httpx", specifier = ">=0.28" },
+    { name = "httpx", specifier = "~=0.28" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jmespath", specifier = ">=1.0.1" },
     { name = "jsonpath-ng", specifier = "!=1.8.0" },


### PR DESCRIPTION
## Description

Fix detached HEAD `git push` failure in the lint job's "Update lock file" step for Dependabot PRs.

The checkout `ref` expression always resolves to a commit SHA, so `git push` fails when `uv lock` produces changes. This explicitly pushes to the Dependabot branch ref instead.

## Closes

- Fixes #750

## Related Issue(s)

- PR #748 (example Dependabot PR that triggered the failure)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Test Framework Affected

- [x] N/A (not test-framework specific)

## Network as Code (NaC) Architecture Affected

- [x] N/A (architecture-agnostic)

## Key Changes

- Changed `git push` to `git push origin HEAD:refs/heads/\${{ github.head_ref }}` in the dependabot lock-file update step
- Updated `uv.lock`

## Testing Done

- [x] Self-review of code completed
- [ ] Will be validated when a Dependabot PR next triggers a `uv.lock` update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of code completed
- [x] No new warnings introduced