### PR TITLE
fix: add str→Path coercion to backward-compatibility shims (#752)

### DIFF
--- a/nac_test/pabot.py
+++ b/nac_test/pabot.py
@@ -9,6 +9,8 @@
 """
 
 import warnings
+from pathlib import Path
+from typing import Any
 
 warnings.warn(
     "'nac_test.pabot' is deprecated and will be removed in a future release. "
@@ -18,6 +20,22 @@ warnings.warn(
     stacklevel=2,
 )
 
-from nac_test.robot.pabot import run_pabot  # noqa: E402, F401
+from nac_test.robot.pabot import run_pabot as _canonical_run_pabot  # noqa: E402
+
+
+def run_pabot(path: str | Path, **kwargs: Any) -> int:
+    """Backward-compatible wrapper for run_pabot with str→Path coercion.
+
+    Args:
+        path: Robot output directory (str or Path).
+        **kwargs: Forwarded to canonical run_pabot.
+
+    Returns:
+        int: Pabot exit code.
+    """
+    if isinstance(path, str):
+        path = Path(path)
+    return _canonical_run_pabot(path, **kwargs)
+
 
 __all__ = ["run_pabot"]

--- a/nac_test/robot_writer.py
+++ b/nac_test/robot_writer.py
@@ -9,6 +9,8 @@
 """
 
 import warnings
+from pathlib import Path
+from typing import Any
 
 warnings.warn(
     "'nac_test.robot_writer' is deprecated and will be removed in a future release. "
@@ -18,6 +20,42 @@ warnings.warn(
     stacklevel=2,
 )
 
-from nac_test.robot.robot_writer import RobotWriter  # noqa: E402, F401
+from nac_test.robot.robot_writer import (  # noqa: E402
+    RobotWriter as _CanonicalRobotWriter,
+)
+
+
+def _coerce_optional_path(value: str | Path | None) -> Path | None:
+    """Coerce a legacy string path to ``Path``, treating empty string as ``None``."""
+    if value is None or value == "":
+        return None
+    return Path(value) if isinstance(value, str) else value
+
+
+class RobotWriter(_CanonicalRobotWriter):
+    """Backward-compatible RobotWriter subclass with str→Path coercion."""
+
+    def __init__(
+        self,
+        data_paths: list[str | Path],
+        filters_path: str | Path | None,
+        tests_path: str | Path | None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize RobotWriter with automatic str→Path coercion.
+
+        Args:
+            data_paths: List of data file paths (str or Path).
+            filters_path: Filters directory path (str, Path, or None; empty str treated as None).
+            tests_path: Tests directory path (str, Path, or None; empty str treated as None).
+            **kwargs: Additional arguments forwarded to canonical RobotWriter.
+        """
+        super().__init__(
+            [Path(p) if isinstance(p, str) else p for p in data_paths],
+            _coerce_optional_path(filters_path),
+            _coerce_optional_path(tests_path),
+            **kwargs,
+        )
+
 
 __all__ = ["RobotWriter"]

--- a/tests/integration/fixtures/compat/data/data.yaml
+++ b/tests/integration/fixtures/compat/data/data.yaml
@@ -1,0 +1,7 @@
+---
+root:
+  children:
+    - name: ABC
+      param: value
+    - name: DEF
+      param: value

--- a/tests/integration/fixtures/compat/deploy/config.j2
+++ b/tests/integration/fixtures/compat/deploy/config.j2
@@ -1,0 +1,5 @@
+[
+{% for child in root.children %}
+  {"name": "{{ child.name }}", "param": "{{ child.param }}"}{% if not loop.last %},{% endif %}
+{% endfor %}
+]

--- a/tests/integration/fixtures/compat/tests/test_check.robot
+++ b/tests/integration/fixtures/compat/tests/test_check.robot
@@ -1,0 +1,9 @@
+*** Settings ***
+Documentation   Compat shim check
+
+*** Test Cases ***
+{% for child in root.children | default([]) %}
+
+Check {{ child.name }}
+    Should Be Equal   {{ child.param }}   value
+{% endfor %}

--- a/tests/integration/test_compat_ci_pipelines.py
+++ b/tests/integration/test_compat_ci_pipelines.py
@@ -29,7 +29,7 @@ def test_deploy_template_rendering_via_shim(tmp_path: Path) -> None:
     fixtures = "tests/integration/fixtures/compat"
     data_dir = f"{fixtures}/data"
     deploy_dir = f"{fixtures}/deploy"
-    output_dir = str(tmp_path / "rendered")
+    output_dir = f"{tmp_path}/rendered"
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
@@ -60,7 +60,7 @@ def test_robot_render_and_run_via_shim(tmp_path: Path) -> None:
     fixtures = "tests/integration/fixtures/compat"
     data_dir = f"{fixtures}/data"
     tests_dir = f"{fixtures}/tests"
-    output_dir = str(tmp_path / "robot_output")
+    output_dir = f"{tmp_path}/robot_output"
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)

--- a/tests/integration/test_compat_ci_pipelines.py
+++ b/tests/integration/test_compat_ci_pipelines.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: MPL-2.0
+# Copyright (c) 2025 Daniel Schmidt
+
+"""Integration tests replicating downstream CI pipeline usage of compatibility shims.
+
+These tests exercise the full backward-compatibility shim layer end-to-end,
+using the exact API patterns found in downstream repos (nac-aci, nac-catalystcenter,
+nac-iosxe, nac-iosxr, nac-meraki, nac-sdwan). All paths are passed as str
+(not Path) to verify that the shim's str→Path coercion works correctly in
+a realistic pipeline scenario.
+"""
+
+import json
+import warnings
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.integration]
+
+
+def test_deploy_template_rendering_via_shim(tmp_path: Path) -> None:
+    """Verify shim RobotWriter renders deploy templates that produce valid JSON.
+
+    Replicates the downstream CI pattern: full_apic_test() → render_templates()
+    → validate_json(). All paths are passed as str to exercise the shim's
+    str→Path coercion.
+    """
+    fixtures = "tests/integration/fixtures/compat"
+    data_dir = f"{fixtures}/data"
+    deploy_dir = f"{fixtures}/deploy"
+    output_dir = str(tmp_path / "rendered")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        from nac_test.robot_writer import RobotWriter
+
+        writer = RobotWriter([data_dir], "", "")
+        # Intentionally passing str (not Path) — downstream repos do this
+        writer.write(deploy_dir, output_dir)  # type: ignore[arg-type]
+
+    # Verify the single expected rendered file is valid JSON
+    rendered_dir = Path(output_dir)
+    rendered_files = [f for f in rendered_dir.iterdir() if f.is_file()]
+    assert rendered_files == [rendered_dir / "config.j2"]
+    data = json.loads((rendered_dir / "config.j2").read_text())
+    assert isinstance(data, list)
+    assert len(data) == 2
+    assert data[0]["name"] == "ABC"
+    assert data[1]["name"] == "DEF"
+
+
+def test_robot_render_and_run_via_shim(tmp_path: Path) -> None:
+    """Verify shim RobotWriter + run_pabot executes rendered robot tests.
+
+    Replicates the downstream CI pattern: apic_render_run_tests() renders
+    robot templates then runs them via pabot. All paths are str to exercise
+    the shim layer's str→Path coercion end-to-end.
+    """
+    fixtures = "tests/integration/fixtures/compat"
+    data_dir = f"{fixtures}/data"
+    tests_dir = f"{fixtures}/tests"
+    output_dir = str(tmp_path / "robot_output")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        import nac_test.pabot
+        from nac_test.robot_writer import RobotWriter
+
+        writer = RobotWriter([data_dir], "", "")
+        # Intentionally passing str (not Path) — downstream repos do this
+        writer.write(tests_dir, output_dir)  # type: ignore[arg-type]
+        exit_code = nac_test.pabot.run_pabot(output_dir)
+
+    assert exit_code == 0, f"pabot returned exit code {exit_code}, expected 0"

--- a/tests/unit/test_compat_shims.py
+++ b/tests/unit/test_compat_shims.py
@@ -64,7 +64,13 @@ def test_shim_emits_deprecation_warning(
         and f"'{legacy_module}' is deprecated" in str(w.message)
     ]
     assert len(shim_warnings) == 1
-    assert getattr(mod, attr) is canonical
+
+    # Shim objects are now wrappers/subclasses, not identical to canonical
+    shim_obj = getattr(mod, attr)
+    if inspect.isclass(shim_obj):
+        assert issubclass(shim_obj, canonical)
+    else:
+        assert callable(shim_obj)
 
 
 @pytest.mark.parametrize(
@@ -84,3 +90,52 @@ def test_shim_signature_reminder(
         if p.default is inspect.Parameter.empty
     }
     assert required == expected_params
+
+
+def test_run_pabot_coerces_str_to_path() -> None:
+    """Verify run_pabot shim coerces str to Path before delegating."""
+    from unittest.mock import patch
+
+    import nac_test.pabot
+
+    with patch("nac_test.pabot._canonical_run_pabot") as mock_canonical:
+        mock_canonical.return_value = 0
+
+        # Test str input → coerced to Path
+        result = nac_test.pabot.run_pabot("some/string/path")
+        assert result == 0
+        mock_canonical.assert_called_once()
+        call_args = mock_canonical.call_args
+        assert call_args[0][0] == Path("some/string/path")
+
+        mock_canonical.reset_mock()
+
+        # Test Path input → passed through unchanged
+        path_input = Path("another/path")
+        result = nac_test.pabot.run_pabot(path_input)
+        assert result == 0
+        mock_canonical.assert_called_once()
+        call_args = mock_canonical.call_args
+        assert call_args[0][0] is path_input
+
+
+def test_robot_writer_coerces_str_args() -> None:
+    """Verify RobotWriter shim coerces str args to Path before delegating."""
+    from unittest.mock import patch
+
+    import nac_test.robot_writer
+
+    with patch(
+        "nac_test.robot_writer._CanonicalRobotWriter.__init__"
+    ) as mock_canonical_init:
+        mock_canonical_init.return_value = None
+
+        # Test str inputs → coerced to Path, empty str → None
+        nac_test.robot_writer.RobotWriter(["data/path1", "data/path2"], "filters/", "")
+
+        mock_canonical_init.assert_called_once()
+        call_args = mock_canonical_init.call_args
+        # When patching __init__, self is not included in call_args
+        assert call_args[0][0] == [Path("data/path1"), Path("data/path2")]
+        assert call_args[0][1] == Path("filters/")
+        assert call_args[0][2] is None

--- a/tests/unit/test_compat_shims.py
+++ b/tests/unit/test_compat_shims.py
@@ -13,6 +13,7 @@ import inspect
 import sys
 import warnings
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -65,6 +66,10 @@ def test_shim_emits_deprecation_warning(
     ]
     assert len(shim_warnings) == 1
 
+    # Warning must NOT point to a specific replacement import path
+    msg = str(shim_warnings[0].message)
+    assert "nac_test.robot." not in msg
+
     # Shim objects are now wrappers/subclasses, not identical to canonical
     shim_obj = getattr(mod, attr)
     if inspect.isclass(shim_obj):
@@ -92,50 +97,133 @@ def test_shim_signature_reminder(
     assert required == expected_params
 
 
-def test_run_pabot_coerces_str_to_path() -> None:
-    """Verify run_pabot shim coerces str to Path before delegating."""
-    from unittest.mock import patch
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("filters", Path("filters")),
+        (Path("filters"), Path("filters")),
+        ("   ", Path("   ")),
+    ],
+    ids=["none", "empty-string", "string", "path", "whitespace-string"],
+)
+def test_coerce_optional_path(value: str | Path | None, expected: Path | None) -> None:
+    """Verify _coerce_optional_path handles all input variants."""
+    from nac_test.robot_writer import _coerce_optional_path
 
+    result = _coerce_optional_path(value)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("path_input", "expected_path"),
+    [
+        ("some/string/path", Path("some/string/path")),
+        (Path("another/path"), Path("another/path")),
+    ],
+    ids=["str", "path"],
+)
+def test_run_pabot_coerces_path_arg(
+    path_input: str | Path, expected_path: Path
+) -> None:
+    """Verify run_pabot shim coerces str to Path before delegating."""
     import nac_test.pabot
 
-    with patch("nac_test.pabot._canonical_run_pabot") as mock_canonical:
-        mock_canonical.return_value = 0
-
-        # Test str input → coerced to Path
-        result = nac_test.pabot.run_pabot("some/string/path")
-        assert result == 0
-        mock_canonical.assert_called_once()
-        call_args = mock_canonical.call_args
-        assert call_args[0][0] == Path("some/string/path")
-
-        mock_canonical.reset_mock()
-
-        # Test Path input → passed through unchanged
-        path_input = Path("another/path")
+    with patch("nac_test.pabot._canonical_run_pabot", return_value=0) as mock:
         result = nac_test.pabot.run_pabot(path_input)
-        assert result == 0
-        mock_canonical.assert_called_once()
-        call_args = mock_canonical.call_args
-        assert call_args[0][0] is path_input
+
+    assert result == 0
+    assert mock.call_args[0][0] == expected_path
 
 
-def test_robot_writer_coerces_str_args() -> None:
-    """Verify RobotWriter shim coerces str args to Path before delegating."""
-    from unittest.mock import patch
+def test_run_pabot_forwards_kwargs() -> None:
+    """Verify run_pabot shim forwards kwargs unchanged to canonical."""
+    import nac_test.pabot
 
+    with patch("nac_test.pabot._canonical_run_pabot", return_value=0) as mock:
+        nac_test.pabot.run_pabot("path", loglevel="DEBUG", console="VERBOSE")
+
+    assert mock.call_args[1] == {"loglevel": "DEBUG", "console": "VERBOSE"}
+
+
+@pytest.mark.parametrize(
+    (
+        "data_paths",
+        "filters_path",
+        "tests_path",
+        "expected_data_paths",
+        "expected_filters_path",
+        "expected_tests_path",
+    ),
+    [
+        (
+            ["data1.yml", "data2.yml"],
+            "filters",
+            "",
+            [Path("data1.yml"), Path("data2.yml")],
+            Path("filters"),
+            None,
+        ),
+        (
+            [Path("data1.yml"), "data2.yml"],
+            None,
+            Path("tests"),
+            [Path("data1.yml"), Path("data2.yml")],
+            None,
+            Path("tests"),
+        ),
+        ([], "", None, [], None, None),
+        (
+            [Path("a.yml")],
+            Path("filters"),
+            Path("tests"),
+            [Path("a.yml")],
+            Path("filters"),
+            Path("tests"),
+        ),
+    ],
+    ids=[
+        "all-strings-empty-tests",
+        "mixed-data-none-filters",
+        "empty-data-no-optionals",
+        "all-paths-passthrough",
+    ],
+)
+def test_robot_writer_coercion_variants(
+    data_paths: list[str | Path],
+    filters_path: str | Path | None,
+    tests_path: str | Path | None,
+    expected_data_paths: list[Path],
+    expected_filters_path: Path | None,
+    expected_tests_path: Path | None,
+) -> None:
+    """Verify RobotWriter shim coerces args for various input combinations."""
     import nac_test.robot_writer
 
     with patch(
-        "nac_test.robot_writer._CanonicalRobotWriter.__init__"
-    ) as mock_canonical_init:
-        mock_canonical_init.return_value = None
+        "nac_test.robot_writer._CanonicalRobotWriter.__init__", return_value=None
+    ) as mock_init:
+        nac_test.robot_writer.RobotWriter(data_paths, filters_path, tests_path)
 
-        # Test str inputs → coerced to Path, empty str → None
-        nac_test.robot_writer.RobotWriter(["data/path1", "data/path2"], "filters/", "")
+    args = mock_init.call_args[0]
+    assert args[0] == expected_data_paths
+    assert args[1] == expected_filters_path
+    assert args[2] == expected_tests_path
 
-        mock_canonical_init.assert_called_once()
-        call_args = mock_canonical_init.call_args
-        # When patching __init__, self is not included in call_args
-        assert call_args[0][0] == [Path("data/path1"), Path("data/path2")]
-        assert call_args[0][1] == Path("filters/")
-        assert call_args[0][2] is None
+
+def test_robot_writer_forwards_kwargs() -> None:
+    """Verify RobotWriter shim forwards kwargs unchanged to canonical."""
+    import nac_test.robot_writer
+
+    with patch(
+        "nac_test.robot_writer._CanonicalRobotWriter.__init__", return_value=None
+    ) as mock_init:
+        nac_test.robot_writer.RobotWriter(
+            ["data.yml"], None, None, include_tags=["tag1"], exclude_tags=["tag2"]
+        )
+
+    assert mock_init.call_args[1] == {
+        "include_tags": ["tag1"],
+        "exclude_tags": ["tag2"],
+    }


### PR DESCRIPTION
## Description

Downstream repos (at least six: nac-aci, nac-catalystcenter, nac-iosxe, nac-iosxr, nac-meraki, nac-sdwan) pass `str` paths where the canonical API expects `Path` objects. This causes `AttributeError: 'str' object has no attribute 'resolve'` in `run_pabot()`, and could break `RobotWriter` if the canonical code tightens its type handling.

The shim layer now coerces `str → Path` before delegating to canonical functions, fixing the crash without touching the mypy-checked production code.

## Closes

- Fixes #752

## Related Issue(s)

- PR #753 (original shim modules)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Technical debt (internal improvements with no user-facing changes)
- [ ] Documentation update
- [ ] Chore (build process, CI, tooling, dependencies)
- [ ] Other (please describe):

## Test Framework Affected

- [ ] PyATS
- [x] Robot Framework
- [ ] Both
- [ ] N/A (not test-framework specific)

## Network as Code (NaC) Architecture Affected

- [ ] ACI (APIC)
- [ ] NDO (Nexus Dashboard Orchestrator)
- [ ] NDFC / VXLAN-EVPN (Nexus Dashboard Fabric Controller)
- [ ] Catalyst SD-WAN (SDWAN Manager / vManage)
- [ ] Catalyst Center (DNA Center)
- [ ] ISE (Identity Services Engine)
- [ ] FMC (Firepower Management Center)
- [ ] Meraki (Cloud-managed)
- [ ] NX-OS (Nexus Direct-to-Device)
- [ ] IOS-XE (Direct-to-Device)
- [ ] IOS-XR (Direct-to-Device)
- [ ] Hyperfabric
- [x] All architectures
- [ ] N/A (architecture-agnostic)

## Platform Tested

- [x] macOS (version tested: macOS Darwin)
- [ ] Linux (distro/version tested: )

## Key Changes

- **`nac_test/pabot.py`**: Replaced direct re-export with a wrapper function that coerces `str` to `Path` before calling canonical `run_pabot`. Accepts `str | Path` for the `path` parameter and forwards all kwargs.
- **`nac_test/robot_writer.py`**: Replaced direct re-export with a `RobotWriter` subclass that coerces constructor args: `data_paths` items `str → Path`, `filters_path`/`tests_path` empty string `"" → None` and non-empty `str → Path`. Extracted repeated coercion logic into `_coerce_optional_path()` helper.
- **`tests/unit/test_compat_shims.py`**: Expanded to 17 tests covering deprecation warnings (with negative assertion: no `nac_test.robot.` in message), signature reminders for `run_pabot` and `RobotWriter`, 5 parametrized `_coerce_optional_path` edge cases (None, empty string, string, Path, whitespace), `run_pabot` coercion variants (str/Path) + kwargs forwarding, and `RobotWriter` coercion variants (all-strings, mixed, empty-data, all-paths passthrough) + kwargs forwarding.
- **`tests/integration/test_compat_ci_pipelines.py`** *(new)*: 2 integration tests replicating downstream CI pipeline patterns end-to-end:
  - `test_deploy_template_rendering_via_shim` — RobotWriter renders Jinja2 deploy templates → validates rendered JSON output (replicates `full_apic_test()` → `render_templates()` → `validate_json()`)
  - `test_robot_render_and_run_via_shim` — RobotWriter renders robot templates → `run_pabot()` executes them, asserts exit code 0 (replicates `apic_render_run_tests()`)
  - All paths passed as `str` via f-string interpolation to exercise shim coercion end-to-end
- **`tests/integration/fixtures/compat/`** *(new)*: Minimal fixture set for compat integration tests — `data/data.yaml`, `deploy/config.j2` (Jinja2 → JSON array), `tests/test_check.robot` (Robot template with passing test cases)

## Testing Done

- [x] Unit tests added/updated
- [x] Integration tests performed
- [ ] Manual testing performed:
  - [ ] PyATS tests executed successfully
  - [x] Robot Framework tests executed successfully
  - [ ] D2D/SSH tests executed successfully (if applicable)
  - [ ] HTML reports generated correctly
- [x] All existing tests pass (`pytest` / `pre-commit run -a`)

### Test Commands Used

```bash
uv run pytest tests/unit/test_compat_shims.py -v        # 17/17 passed
uv run pytest tests/integration/test_compat_ci_pipelines.py -v  # 2/2 passed
uv run pre-commit run -a                                 # all passed
```

## Checklist

- [x] Code follows project style guidelines (`pre-commit run -a` passes)
- [x] Self-review of code completed
- [x] Code is commented where necessary (especially complex logic)
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Changes work on both macOS and Linux
- [ ] CHANGELOG.md updated (if applicable)

## Screenshots (if applicable)

N/A

## Additional Notes

**Root cause**: Downstream repos use `os.path.join()` and string literals for paths (e.g. `nac_test.pabot.run_pabot(os.path.join(tmpdir, "results/"))`), which produce `str`. The canonical `run_pabot` calls `path.resolve()` at line 93 of `robot/pabot.py`, which fails on `str`. Similarly, `RobotWriter` is called with `filters_path=""` and `tests_path=""` (empty strings) instead of `None`, and `data_paths` as `list[str]` instead of `list[Path]`.

**Downstream type usage summary** (from Jenkinsfile/test analysis):

| Parameter | Expected | Actual (downstream) |
|-----------|----------|-------------------|
| `run_pabot(path)` | `Path` | `str` (from `os.path.join`) |
| `RobotWriter(data_paths)` | `list[Path]` | `list[str]` (nac-aci, meraki, sdwan, catalystcenter) |
| `RobotWriter(filters_path)` | `Path \| None` | `str` (e.g. `"jinja_filters/"` or `""`) |
| `RobotWriter(tests_path)` | `Path \| None` | `""` (empty string in all repos) |