### PR TITLE
fix(ci): add artifactory credentials to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,17 @@ on:
     tags:
       - "v*"
 
+env:
+  # Artifactory credentials for resolving build dependencies (e.g. hatchling)
+  # via the default index configured in pyproject.toml.
+  # No UV_DEFAULT_INDEX fallback needed here — unlike test.yml, releases only
+  # trigger on tag pushes to the main repo where secrets are always available.
+  UV_INDEX_CISCO_ARTIFACTORY_DEVHUB_USERNAME: ${{ secrets.UV_INDEX_CISCO_ARTIFACTORY_DEVHUB_USERNAME }}
+  UV_INDEX_CISCO_ARTIFACTORY_DEVHUB_PASSWORD: ${{ secrets.UV_INDEX_CISCO_ARTIFACTORY_DEVHUB_PASSWORD }}
+  UV_HTTP_TIMEOUT: 120
+  UV_HTTP_CONNECT_TIMEOUT: 30
+  UV_HTTP_RETRIES: 10
+
 jobs:
   test:
     uses: ./.github/workflows/test.yml


### PR DESCRIPTION
## Description

PR #744 added Cisco Artifactory as the default PyPI index in `pyproject.toml` but only configured credentials in `test.yml`. The release pipeline failed with 401 Unauthorized when `uv build` tried to resolve `hatchling` from the authenticated artifactory.

## Closes

- Fixes #

## Related Issue(s)

- #744

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Technical debt (internal improvements with no user-facing changes)
- [ ] Documentation update
- [ ] Chore (build process, CI, tooling, dependencies)
- [ ] Other (please describe):

## Test Framework Affected

- [ ] PyATS
- [ ] Robot Framework
- [ ] Both
- [x] N/A (not test-framework specific)

## Network as Code (NaC) Architecture Affected

- [ ] ACI (APIC)
- [ ] NDO (Nexus Dashboard Orchestrator)
- [ ] NDFC / VXLAN-EVPN (Nexus Dashboard Fabric Controller)
- [ ] Catalyst SD-WAN (SDWAN Manager / vManage)
- [ ] Catalyst Center (DNA Center)
- [ ] ISE (Identity Services Engine)
- [ ] FMC (Firepower Management Center)
- [ ] Meraki (Cloud-managed)
- [ ] NX-OS (Nexus Direct-to-Device)
- [ ] IOS-XE (Direct-to-Device)
- [ ] IOS-XR (Direct-to-Device)
- [ ] Hyperfabric
- [ ] All architectures
- [x] N/A (architecture-agnostic)

## Platform Tested

- [ ] macOS (version tested: )
- [ ] Linux (distro/version tested: )

## Key Changes

- Added workflow-level `env` block to `release.yml` with `UV_INDEX_CISCO_ARTIFACTORY_DEVHUB_USERNAME/PASSWORD` secrets and HTTP timeout/retry settings
- No `UV_DEFAULT_INDEX` fallback needed — unlike `test.yml`, releases only trigger on tag pushes where secrets are always available

## Testing Done

- [ ] Unit tests added/updated
- [ ] Integration tests performed
- [x] Manual testing performed:
  - [ ] PyATS tests executed successfully
  - [ ] Robot Framework tests executed successfully
  - [ ] D2D/SSH tests executed successfully (if applicable)
  - [ ] HTML reports generated correctly
- [ ] All existing tests pass (`pytest` / `pre-commit run -a`)

### Test Commands Used

```bash
# Verified against failed run: https://github.com/netascode/nac-test/actions/runs/24463968652/job/71486664660
# Will be validated by re-tagging after merge
```

## Checklist

- [x] Code follows project style guidelines (`pre-commit run -a` passes)
- [x] Self-review of code completed
- [x] Code is commented where necessary (especially complex logic)
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced
- [x] Changes work on both macOS and Linux
- [ ] CHANGELOG.md updated (if applicable)

## Additional Notes

The failed release run error was:
```
Failed to resolve requirements from `build-system.requires`
No solution found when resolving: `hatchling`
hint: An index URL (https://artifactory.devhub-cloud.cisco.com/...) could not be queried
due to a lack of valid authentication credentials (401 Unauthorized).
```