### PR TITLE
Consolidation of Genie parsing logic to Connection Broker

### DIFF
--- a/nac_test/pyats_core/broker/broker_client.py
+++ b/nac_test/pyats_core/broker/broker_client.py
@@ -126,6 +126,7 @@ class BrokerClient:
 
             # Read response data
             response_data = await self.reader.readexactly(response_length)
+            logger.debug(f"Received response of length: {response_length} bytes")
             response = json.loads(response_data.decode("utf-8"))
 
             # Check for errors
@@ -164,6 +165,37 @@ class BrokerClient:
         logger.debug(f"Command output length: {len(result)} characters")
 
         return result  # type: ignore[no-any-return]
+
+    async def parse_command(
+        self, hostname: str, command: str, return_raw: bool = False
+    ) -> dict[str, Any]:
+        """Parse command output on device through broker.
+
+        Args:
+            hostname: Device hostname
+            command: Command to parse
+            return_raw: Whether to return raw output along with parsed result
+
+        Returns:
+            Tuple containing parsed output dictionary and optionally raw output
+
+        Raises:
+            ConnectionError: If broker communication fails
+        """
+        logger.debug(
+            f"Parsing command on {hostname}: {command} (return_raw={return_raw})"
+        )
+
+        response = await self._send_request(
+            {
+                "command": "parse",
+                "hostname": hostname,
+                "cmd": command,
+                "return_raw": return_raw,
+            }
+        )
+
+        return response.get("result", {})  # type: ignore[no-any-return]
 
     async def ensure_connection(self, hostname: str) -> bool:
         """Ensure device is connected through broker.
@@ -257,6 +289,23 @@ class BrokerCommandExecutor:
             Command output
         """
         return await self.broker_client.execute_command(self.hostname, command)
+
+    async def parse(
+        self, command: str, return_raw: bool = False
+    ) -> tuple[dict[str, Any], str | None]:
+        """Parse command output on device via broker.
+
+        Args:
+            command: Command to parse
+            return_raw: Whether to return raw output along with parsed result
+
+        Returns:
+            Dictionary containing parsed output and optionally raw output
+        """
+        result = await self.broker_client.parse_command(
+            self.hostname, command, return_raw
+        )
+        return result.get("parsed", {}), result.get("raw", None)
 
     async def connect(self) -> None:
         """Ensure device connection via broker."""

--- a/nac_test/pyats_core/broker/connection_broker.py
+++ b/nac_test/pyats_core/broker/connection_broker.py
@@ -199,6 +199,19 @@ class ConnectionBroker:
 
                 result = await self._execute_command(hostname, cmd_string)
                 return {"status": "success", "result": result}
+            elif command == "parse":
+                hostname = message.get("hostname")
+                return_raw = message.get("return_raw", False)
+                cmd = message.get("cmd")
+
+                if not hostname or not cmd:
+                    return {
+                        "status": "error",
+                        "error": "Missing hostname or cmd parameter",
+                    }
+
+                result = await self._parse_command(hostname, cmd, return_raw)
+                return {"status": "success", "result": result}
 
             elif command == "connect":
                 hostname = message.get("hostname")
@@ -253,9 +266,10 @@ class ConnectionBroker:
         # Check cache first
         cached_output = cache.get(cmd)
         if cached_output is not None:
-            self.stats_command_cache_hits += 1
-            logger.debug(f"Broker cache hit for '{cmd}' on {hostname}")
-            return cached_output
+            if cached_output.output is not None:
+                self.stats_command_cache_hits += 1
+                logger.debug(f"Broker cache hit for '{cmd}' on {hostname}")
+                return cached_output.output
 
         # Command not in cache, need to execute
         self.stats_command_cache_misses += 1
@@ -271,7 +285,7 @@ class ConnectionBroker:
             output_str = str(output)
 
             # Cache the output for future requests
-            cache.set(cmd, output_str)
+            cache.set(cmd, output=output_str)
             logger.info(
                 f"Cached command output for '{cmd}' on {hostname} ({len(output_str)} chars)"
             )
@@ -281,6 +295,58 @@ class ConnectionBroker:
             logger.error(f"Command execution failed on {hostname}: {e}")
             # Try to reconnect on failure
             await self._disconnect_device(hostname)
+            raise
+
+    async def _parse_command(self, hostname: str, cmd: str, return_raw: bool) -> Any:
+        """Execute command and return parsed output using Genie parsers."""
+        # Get or create cache for this device
+        if hostname not in self.command_cache:
+            self.command_cache[hostname] = CommandCache(
+                hostname, ttl=3600
+            )  # 1 hour TTL
+            logger.info(f"Created command cache for device: {hostname}")
+
+        cache = self.command_cache[hostname]
+        cache_entry = cache.get(cmd)
+        if cache_entry is not None:
+            if cache_entry.parsed_output is not None:
+                self.stats_command_cache_hits += 1
+                logger.debug(f"Broker cache hit for parsed '{cmd}' on {hostname}")
+                return {
+                    "parsed": cache_entry.parsed_output,
+                    "raw": cache_entry.output if return_raw else None,
+                }
+
+        # Command not in cache, need to execute and parse
+        self.stats_command_cache_misses += 1
+        logger.debug(
+            f"Broker cache miss for parsed '{cmd}' on {hostname}, executing..."
+        )
+
+        # Ensure device is connected
+        connection = await self._get_connection(hostname)
+
+        # Execute command in thread pool (since Unicon is synchronous)
+        loop = get_or_create_event_loop()
+        if return_raw:
+            try:
+                output = await loop.run_in_executor(None, connection.execute, cmd)
+            except Exception as e:
+                logger.error(f"Command execution failed on {hostname}: {e}")
+                # Try to reconnect on failure
+                await self._disconnect_device(hostname)
+                raise
+        else:
+            output = None  # Don't retrieve raw output if not requested
+        try:
+            parsed_output = await loop.run_in_executor(None, connection.parse, cmd)
+            cache.set(cmd, output=output, parsed_output=parsed_output)
+            return {
+                "parsed": dict(parsed_output),
+                "raw": output if return_raw else None,
+            }
+        except Exception as e:
+            logger.error(f"Command parsing failed on {hostname}: {e}")
             raise
 
     async def _get_connection(self, hostname: str) -> Any:

--- a/nac_test/pyats_core/common/ssh_base_test.py
+++ b/nac_test/pyats_core/common/ssh_base_test.py
@@ -247,9 +247,9 @@ class SSHTestBase(NACTestBase):
         self.device_data = self.device_info
         # hostname already set in setup_ssh_context
 
-    def parse_output(
-        self, command: str, output: str | None = None
-    ) -> dict[str, Any] | None:
+    async def parse_output(
+        self, command: str, return_raw: bool = False
+    ) -> tuple[dict[str, Any] | None, str | None]:
         """Parse command output using Genie parser if available.
 
         This method attempts to use Genie parsers when a PyATS testbed is available.
@@ -257,28 +257,18 @@ class SSHTestBase(NACTestBase):
 
         Args:
             command: The command whose output should be parsed
-            output: Optional pre-fetched command output. If not provided,
-                   the command will be executed.
 
         Returns:
-            Parsed output dictionary if successful, None otherwise.
+            Tuple containing parsed output dictionary and optionally raw output if successful, None otherwise.
         """
-        # If we have a testbed device, use its parse method
-        if self.testbed_device:
-            try:
-                if output is not None:
-                    # Parse provided output
-                    result = self.testbed_device.parse(command, output=output)
-                    return dict(result) if result is not None else None
-                else:
-                    # Execute and parse in one step
-                    result = self.testbed_device.parse(command)
-                    return dict(result) if result is not None else None
-            except Exception as e:
-                self.logger.warning(f"Genie parser failed for '{command}': {e}")
-                return None
+
+        if self.connection is not None:
+            return await self.connection.parse(command, return_raw=return_raw)
+        elif self.testbed_device:
+            parsed_output = dict(self.testbed_device.parse(command))
+            return parsed_output, None
         else:
-            return None
+            return None, None
 
     def _create_execute_command_method(
         self, connection: Any, command_cache: CommandCache
@@ -307,10 +297,11 @@ class SSHTestBase(NACTestBase):
             # Check cache first
             cached_output = command_cache.get(command)
             if cached_output is not None:
-                logging.debug(f"Using cached output for command: {command}")
-                # Track cached command execution for reporting
-                test_instance._track_ssh_command(command, cached_output)
-                return cached_output
+                if cached_output.output is not None:
+                    logging.debug(f"Using cached output for command: {command}")
+                    # Track cached command execution for reporting
+                    test_instance._track_ssh_command(command, cached_output.output)
+                    return cached_output.output
 
             # Execute command via connection (broker or testbed device)
             logging.debug(f"Executing command: {command}")
@@ -329,7 +320,7 @@ class SSHTestBase(NACTestBase):
             output_str = str(output)
 
             # Cache the output
-            command_cache.set(command, output_str)
+            command_cache.set(command, output=output_str)
 
             # Track the command execution for reporting
             test_instance._track_ssh_command(command, output_str)

--- a/nac_test/pyats_core/ssh/command_cache.py
+++ b/nac_test/pyats_core/ssh/command_cache.py
@@ -14,6 +14,15 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+class CacheEntry:
+    """Represents a single cache entry for a command output."""
+
+    def __init__(self, output: str | None = None, parsed_output: Any | None = None):
+        self.output: str | None = output
+        self.parsed_output: Any | None = parsed_output
+        self.timestamp: float = time.time()
+
+
 class CommandCache:
     """Per-device command output cache with TTL support.
 
@@ -34,11 +43,11 @@ class CommandCache:
         """
         self.hostname = hostname
         self.ttl = ttl
-        self.cache: dict[str, dict[str, Any]] = {}  # command -> {output, timestamp}
+        self.cache: dict[str, CacheEntry] = {}  # command -> CacheEntry
 
         logger.debug(f"Initialized command cache for device {hostname} with TTL {ttl}s")
 
-    def get(self, command: str) -> str | None:
+    def get(self, command: str) -> CacheEntry | None:
         """Get cached command output if valid.
 
         Args:
@@ -49,9 +58,9 @@ class CommandCache:
         """
         if command in self.cache:
             entry = self.cache[command]
-            if time.time() - entry["timestamp"] < self.ttl:
+            if time.time() - entry.timestamp < self.ttl:
                 logger.debug(f"Cache hit for '{command}' on {self.hostname}")
-                return str(entry["output"])
+                return entry
             else:
                 # Entry has expired, remove it
                 del self.cache[command]
@@ -59,17 +68,23 @@ class CommandCache:
 
         return None
 
-    def set(self, command: str, output: str) -> None:
+    def set(
+        self, command: str, output: str | None = None, parsed_output: Any | None = None
+    ) -> None:
         """Cache command output with current timestamp.
 
         Args:
             command: The command that was executed
             output: The command output to cache
+            parsed_output: The parsed command output to cache (optional)
         """
-        self.cache[command] = {"output": output, "timestamp": time.time()}
-        logger.debug(
-            f"Cached '{command}' output for {self.hostname} ({len(output)} chars)"
-        )
+        self.cache[command] = CacheEntry(output, parsed_output)
+        if output is not None:
+            logger.debug(
+                f"Cached '{command}' output for {self.hostname} ({len(output)} chars)"
+            )
+        if parsed_output is not None:
+            logger.debug(f"Cached '{command}' parsed output for {self.hostname}")
 
     def clear(self) -> None:
         """Clear all cached entries for this device."""
@@ -91,7 +106,7 @@ class CommandCache:
         valid_count = 0
 
         for entry in self.cache.values():
-            if current_time - entry["timestamp"] >= self.ttl:
+            if current_time - entry.timestamp >= self.ttl:
                 expired_count += 1
             else:
                 valid_count += 1

--- a/tests/e2e/fixtures/failure/templates/tests/verify_iosxe_control_fail.py
+++ b/tests/e2e/fixtures/failure/templates/tests/verify_iosxe_control_fail.py
@@ -80,12 +80,8 @@ class VerifySdwanTunnelStatistics(IOSXETestBase):
                 start_time = time.time()
 
                 try:
-                    with self.test_context(api_context):
-                        output = await self.execute_command(command)
-                    command_duration = time.time() - start_time
-
                     parse_start = time.time()
-                    parsed_output = self.parse_output(command, output=output)
+                    parsed_output, _ = await self.parse_output(command)
                     parse_duration = time.time() - parse_start
 
                 except Exception as e:
@@ -101,7 +97,7 @@ class VerifySdwanTunnelStatistics(IOSXETestBase):
                         api_duration=api_duration,
                     )
 
-                api_duration = command_duration + parse_duration
+                api_duration = parse_duration
                 context["api_context"] = api_context
 
                 # Check if parsed output is empty or None

--- a/tests/e2e/fixtures/mixed/templates/tests/verify_iosxe_control.py
+++ b/tests/e2e/fixtures/mixed/templates/tests/verify_iosxe_control.py
@@ -124,12 +124,9 @@ class VerifySdwanControlConnectionsState(IOSXETestBase):
                 start_time = time.time()
 
                 try:
-                    with self.test_context(api_context):
-                        output = await self.execute_command(command)
-                    command_duration = time.time() - start_time
 
                     parse_start = time.time()
-                    parsed_output = self.parse_output(command, output=output)
+                    parsed_output, _ = await self.parse_output(command)
                     parse_duration = time.time() - parse_start
 
                 except Exception as e:
@@ -155,7 +152,7 @@ class VerifySdwanControlConnectionsState(IOSXETestBase):
                         api_duration=api_duration,
                     )
 
-                api_duration = command_duration + parse_duration
+                api_duration = parse_duration
 
                 context["api_context"] = api_context
 

--- a/tests/e2e/fixtures/pyats_cc/templates/tests/verify_iosxe_no_critical_errors_in_system_logs.py
+++ b/tests/e2e/fixtures/pyats_cc/templates/tests/verify_iosxe_no_critical_errors_in_system_logs.py
@@ -138,15 +138,11 @@ class VerifyNoCriticalErrorsInSystemLogs(IOSXETestBase):
 
                 start_time = time.time()
 
-                with self.test_context(api_context):
-                    output = await self.execute_command(command)
-                command_duration = time.time() - start_time
-
                 parse_start = time.time()
-                parsed_output = self.parse_output(command, output=output)
+                parsed_output, _ = await self.parse_output(command)
                 parse_duration = time.time() - parse_start
 
-                api_duration = command_duration + parse_duration
+                api_duration = parse_duration
 
                 context["api_context"] = api_context
 

--- a/tests/e2e/fixtures/pyats_d2d_only/templates/tests/verify_iosxe_control.py
+++ b/tests/e2e/fixtures/pyats_d2d_only/templates/tests/verify_iosxe_control.py
@@ -124,12 +124,12 @@ class VerifySdwanControlConnectionsState(IOSXETestBase):
                 start_time = time.time()
 
                 try:
-                    with self.test_context(api_context):
-                        output = await self.execute_command(command)
-                    command_duration = time.time() - start_time
+                    # with self.test_context(api_context):
+                    #     output = await self.execute_command(command)
+                    # command_duration = time.time() - start_time
 
                     parse_start = time.time()
-                    parsed_output = self.parse_output(command, output=output)
+                    parsed_output, _ = await self.parse_output(command)
                     parse_duration = time.time() - parse_start
 
                 except Exception as e:
@@ -155,7 +155,7 @@ class VerifySdwanControlConnectionsState(IOSXETestBase):
                         api_duration=api_duration,
                     )
 
-                api_duration = command_duration + parse_duration
+                api_duration = parse_duration
 
                 context["api_context"] = api_context
 

--- a/tests/e2e/fixtures/success/templates/tests/verify_iosxe_control.py
+++ b/tests/e2e/fixtures/success/templates/tests/verify_iosxe_control.py
@@ -129,7 +129,7 @@ class VerifySdwanControlConnectionsState(IOSXETestBase):
                     command_duration = time.time() - start_time
 
                     parse_start = time.time()
-                    parsed_output = self.parse_output(command, output=output)
+                    parsed_output, _ = await self.parse_output(command)
                     parse_duration = time.time() - parse_start
 
                 except Exception as e:

--- a/tests/integration/fixtures/templates_broker/tests/test_broker_pooling_1.py
+++ b/tests/integration/fixtures/templates_broker/tests/test_broker_pooling_1.py
@@ -124,12 +124,9 @@ class BrokerPoolingTest1(IOSXETestBase):
                 start_time = time.time()
 
                 try:
-                    with self.test_context(api_context):
-                        output = await self.execute_command(command)
-                    command_duration = time.time() - start_time
 
                     parse_start = time.time()
-                    parsed_output = self.parse_output(command, output=output)
+                    parsed_output, _ = await self.parse_output(command)
                     parse_duration = time.time() - parse_start
 
                 except Exception as e:
@@ -150,7 +147,7 @@ class BrokerPoolingTest1(IOSXETestBase):
                         api_duration=api_duration,
                     )
 
-                api_duration = command_duration + parse_duration
+                api_duration = parse_duration
 
                 context['api_context'] = api_context
 

--- a/tests/integration/fixtures/templates_broker/tests/test_broker_pooling_2.py
+++ b/tests/integration/fixtures/templates_broker/tests/test_broker_pooling_2.py
@@ -124,12 +124,8 @@ class BrokerPoolingTest2(IOSXETestBase):
                 start_time = time.time()
 
                 try:
-                    with self.test_context(api_context):
-                        output = await self.execute_command(command)
-                    command_duration = time.time() - start_time
-
                     parse_start = time.time()
-                    parsed_output = self.parse_output(command, output=output)
+                    parsed_output, _ = await self.parse_output(command)
                     parse_duration = time.time() - parse_start
 
                 except Exception as e:
@@ -150,7 +146,7 @@ class BrokerPoolingTest2(IOSXETestBase):
                         api_duration=api_duration,
                     )
 
-                api_duration = command_duration + parse_duration
+                api_duration = parse_duration
 
                 context['api_context'] = api_context
 

--- a/tests/integration/fixtures/templates_broker/tests/test_broker_pooling_3.py
+++ b/tests/integration/fixtures/templates_broker/tests/test_broker_pooling_3.py
@@ -124,12 +124,8 @@ class BrokerPoolingTest3(IOSXETestBase):
                 start_time = time.time()
 
                 try:
-                    with self.test_context(api_context):
-                        output = await self.execute_command(command)
-                    command_duration = time.time() - start_time
-
                     parse_start = time.time()
-                    parsed_output = self.parse_output(command, output=output)
+                    parsed_output, _ = await self.parse_output(command)
                     parse_duration = time.time() - parse_start
 
                 except Exception as e:
@@ -150,7 +146,7 @@ class BrokerPoolingTest3(IOSXETestBase):
                         api_duration=api_duration,
                     )
 
-                api_duration = command_duration + parse_duration
+                api_duration = parse_duration
 
                 context['api_context'] = api_context
 

--- a/tests/unit/pyats_core/broker/test_connection_broker.py
+++ b/tests/unit/pyats_core/broker/test_connection_broker.py
@@ -17,6 +17,7 @@ import pytest
 
 from nac_test.pyats_core.broker.broker_client import BrokerClient, BrokerCommandExecutor
 from nac_test.pyats_core.broker.connection_broker import ConnectionBroker
+from nac_test.pyats_core.ssh.command_cache import CacheEntry
 
 
 @pytest.fixture
@@ -158,6 +159,26 @@ class TestProcessRequest:
         assert result == {"status": "success", "result": "show version output"}
         broker._execute_command.assert_called_once_with("router-1", "show version")
 
+    def test_parse_calls_parse_command(self, broker: ConnectionBroker) -> None:
+        broker._parse_command = AsyncMock(  # type: ignore[method-assign]
+            return_value={"parsed": {"parsed_data": {}}, "raw": "show version output"}
+        )
+        result = asyncio.run(
+            broker._process_request(
+                {
+                    "command": "parse",
+                    "hostname": "router-1",
+                    "return_raw": True,
+                    "cmd": "show version",
+                }
+            )
+        )
+        assert result == {
+            "status": "success",
+            "result": {"parsed": {"parsed_data": {}}, "raw": "show version output"},
+        }
+        broker._parse_command.assert_called_once_with("router-1", "show version", True)
+
 
 # ---------------------------------------------------------------------------
 # _get_connection — cache hit/miss and stats
@@ -213,7 +234,7 @@ class TestGetConnection:
 class TestExecuteCommand:
     def test_cache_hit_skips_device(self, broker: ConnectionBroker) -> None:
         cache = MagicMock()
-        cache.get.return_value = "cached output"
+        cache.get.return_value = CacheEntry(output="cached output")
         broker.command_cache["router-1"] = cache
         broker._get_connection = AsyncMock()  # type: ignore[method-assign]
 
@@ -248,7 +269,7 @@ class TestExecuteCommand:
         result = asyncio.run(_run())
 
         assert result == "live output"
-        cache.set.assert_called_once_with("show version", "live output")
+        cache.set.assert_called_once_with("show version", output="live output")
         assert broker.stats_command_cache_misses == 1
 
     def test_cache_miss_raises_when_connection_fails(
@@ -263,6 +284,72 @@ class TestExecuteCommand:
 
         with pytest.raises(ConnectionError):
             asyncio.run(broker._execute_command("router-1", "show version"))
+
+
+# ---------------------------------------------------------------------------
+# _parse_command — command cache hit/miss
+# ---------------------------------------------------------------------------
+
+
+class TestParseCommand:
+    def test_cache_hit_skips_device(self, broker: ConnectionBroker) -> None:
+        cache = MagicMock()
+        cache.get.return_value = CacheEntry(
+            parsed_output={"output:": "cached parsed"}, output=None
+        )
+        broker.command_cache["router-1"] = cache
+        broker._get_connection = AsyncMock()  # type: ignore[method-assign]
+
+        result = asyncio.run(broker._parse_command("router-1", "show version", False))
+
+        assert result == {"parsed": {"output:": "cached parsed"}, "raw": None}
+        broker._get_connection.assert_not_called()
+        assert broker.stats_command_cache_hits == 1
+
+    def test_cache_miss_executes_and_stores(self, broker: ConnectionBroker) -> None:
+        cache = MagicMock()
+        cache.get.return_value = None
+        broker.command_cache["router-1"] = cache
+
+        conn = MagicMock()
+        broker._get_connection = AsyncMock(return_value=conn)  # type: ignore[method-assign]
+
+        async def _run() -> str:
+            loop = asyncio.get_event_loop()
+            with patch(
+                "nac_test.pyats_core.broker.connection_broker.get_or_create_event_loop",
+                return_value=loop,
+            ):
+                with patch.object(
+                    loop,
+                    "run_in_executor",
+                    new_callable=AsyncMock,
+                    return_value={"output:": "cached parsed"},
+                ):
+                    return await broker._parse_command(  # type: ignore[no-any-return]
+                        "router-1", "show version", False
+                    )
+
+        result = asyncio.run(_run())
+
+        assert result == {"parsed": {"output:": "cached parsed"}, "raw": None}
+        cache.set.assert_called_once_with(
+            "show version", parsed_output={"output:": "cached parsed"}, output=None
+        )
+        assert broker.stats_command_cache_misses == 1
+
+    def test_cache_miss_raises_when_connection_fails(
+        self, broker: ConnectionBroker
+    ) -> None:
+        cache = MagicMock()
+        cache.get.return_value = None
+        broker.command_cache["router-1"] = cache
+        broker._get_connection = AsyncMock(  # type: ignore[method-assign]
+            side_effect=ConnectionError("No testbed loaded for router-1")
+        )
+
+        with pytest.raises(ConnectionError):
+            asyncio.run(broker._parse_command("router-1", "show version", False))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

PR consolidates genir parsing logic to ConnectionBroker with storage of parsed output retained in CommandCache.

## Related Issue(s)

This is related to #663 where previously parsing of previously fetched command output that already existed in cache was not working correctly based on discovered logic in Genie Parsers. 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactoring / Technical debt (internal improvements with no user-facing changes)
- [ ] Documentation update
- [ ] Chore (build process, CI, tooling, dependencies)
- [ ] Other (please describe):

## Test Framework Affected

- [X] PyATS
- [ ] Robot Framework
- [ ] Both
- [ ] N/A (not test-framework specific)

## Network as Code (NaC) Architecture Affected

<!-- See https://netascode.cisco.com for supported architectures -->

- [ ] ACI (APIC)
- [ ] NDO (Nexus Dashboard Orchestrator)
- [ ] NDFC / VXLAN-EVPN (Nexus Dashboard Fabric Controller)
- [ ] Catalyst SD-WAN (SDWAN Manager / vManage)
- [ ] Catalyst Center (DNA Center)
- [ ] ISE (Identity Services Engine)
- [ ] FMC (Firepower Management Center)
- [ ] Meraki (Cloud-managed)
- [ ] NX-OS (Nexus Direct-to-Device)
- [X] IOS-XE (Direct-to-Device)
- [ ] IOS-XR (Direct-to-Device)
- [ ] Hyperfabric
- [ ] All architectures
- [ ] N/A (architecture-agnostic)

## Platform Tested

> nac-test supports macOS and Linux only

- [ ] macOS (version tested: )
- [X] Linux (distro/version tested: Unbuntu 24.04)

## Key Changes

<!--
Summarize the main changes in this PR:
 - Updates to CommandCache class to also store parsed output alongside command output
 - Changes to Broker logic to process 'parse' commands
 - move genie parsing into the broker itself when processing a 'parse' command
 - updates to unit/fixture/e2e tests to accomodate api changes
-->

## Testing Done

- [X] Unit tests added/updated
- [X] Integration tests performed
- [X] Manual testing performed:
  - [X] PyATS tests executed successfully
  - [X] Robot Framework tests executed successfully
  - [X] D2D/SSH tests executed successfully (if applicable)
  - [X] HTML reports generated correctly
- [X] All existing tests pass (`pytest` / `pre-commit run -a`)

### Test Commands Used

```bash
uv run pytest -n auto --dist loadscope tests/
```

## Checklist

- [X] Code follows project style guidelines (`pre-commit run -a` passes)
- [X] Self-review of code completed
- [X] Code is commented where necessary (especially complex logic)
- [ ] Documentation updated (if applicable)
- [X] No new warnings introduced
- [ ] Changes work on both macOS and Linux
- [ ] CHANGELOG.md updated (if applicable)

## Additional Notes

This change is currently causing tests to directly call 'parse_output' instead of 'execute_command' > 'parse_output' which does impact visual of test results as raw command output is no longer present.  Default genie api's do not return command output from a 'parse()' call.  This could be changed with providing the 'return_raw=True' optional arg to the 'parse_output' fn.
