### PR TITLE
chore: check uv.lock is up-to-date

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,12 @@ repos:
       - id: bandit
         args: ['-c', 'pyproject.toml', '-r', 'nac_test/']
         exclude: ^tests/
+
+  - repo: local
+    hooks:
+      - id: uv-lock-up-to-date
+        name: Check uv.lock is up-to-date
+        entry: uv lock --check
+        language: system
+        pass_filenames: false
+        files: ^(pyproject\.toml|uv\.lock)$


### PR DESCRIPTION
## Description

Add a scoped pre-commit hook to verify `uv.lock` is up-to-date (matches pipeline lockfile check).

## Closes

- Fixes #

## Related Issue(s)

-

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Technical debt (internal improvements with no user-facing changes)
- [ ] Documentation update
- [x] Chore (build process, CI, tooling, dependencies)
- [ ] Other (please describe):

## Test Framework Affected

- [ ] PyATS
- [ ] Robot Framework
- [ ] Both
- [x] N/A (not test-framework specific)

## Network as Code (NaC) Architecture Affected

- [ ] ACI (APIC)
- [ ] NDO (Nexus Dashboard Orchestrator)
- [ ] NDFC / VXLAN-EVPN (Nexus Dashboard Fabric Controller)
- [ ] Catalyst SD-WAN (SDWAN Manager / vManage)
- [ ] Catalyst Center (DNA Center)
- [ ] ISE (Identity Services Engine)
- [ ] FMC (Firepower Management Center)
- [ ] Meraki (Cloud-managed)
- [ ] NX-OS (Nexus Direct-to-Device)
- [ ] IOS-XE (Direct-to-Device)
- [ ] IOS-XR (Direct-to-Device)
- [ ] Hyperfabric
- [ ] All architectures
- [ ] N/A (architecture-agnostic)

## Platform Tested

> nac-test supports macOS and Linux only

- [x] macOS (version tested: )
- [ ] Linux (distro/version tested: )

## Key Changes

- Add `uv lock --check` pre-commit hook scoped to `pyproject.toml` and `uv.lock`.

## Testing Done

- [x] All existing tests pass (`pre-commit validate-config`)

### Test Commands Used

```bash
pre-commit validate-config .pre-commit-config.yaml
```

## Checklist

- [ ] Code follows project style guidelines (`pre-commit run -a` passes)
- [x] Self-review of code completed
- [ ] Code is commented where necessary (especially complex logic)
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced
- [ ] Changes work on both macOS and Linux
- [ ] CHANGELOG.md updated (if applicable)

## Screenshots (if applicable)

## Additional Notes