### PR TITLE
Add sdwan (20.18+) jwt token based auth support for pyats nac-test testcases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _Note: This changelog covers all 2.0.0 alpha and beta releases._
 - **Merged xUnit Output**: Robot and pyATS results merged into single `xunit.xml` for CI/CD integration
 - **Diagnostic Collection**: `--diagnostic` flag wraps execution to collect troubleshooting info (env, packages, logs)
 - **Fail-Fast Authentication**: Controller authentication validated before pyATS test execution starts
+- **Credential Sets with `auth_method`**: Controllers now define ordered `credential_sets` instead of flat env var lists. Each `CredentialSet` carries an `auth_method` attribute (e.g., `"token"`, `"session"`) so downstream auth adapters can determine which mechanism to use. SD-WAN supports API Token (20.18+) and Username/Password — the first satisfied set wins and is remembered via `get_matched_credential_set()` API.
 
 ## Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Diagnostic Collection**: `--diagnostic` flag wraps execution to collect troubleshooting info (env, packages, logs)
 - **Fail-Fast Authentication**: Controller authentication validated before pyATS test execution starts
 - **Credential Sets with `auth_method`**: Controllers now define ordered `credential_sets` instead of flat env var lists. Each `CredentialSet` carries an `auth_method` attribute (e.g., `"token"`, `"session"`) so downstream auth adapters can determine which mechanism to use. SD-WAN supports API Token (20.18+) and Username/Password — the first satisfied set wins and is remembered via `get_matched_credential_set()` API.
+- **Unified credential set handling for IOSXE**: Removed `alt_url_env_vars` mechanism. IOSXE alternative URL support (`IOSXE_HOST`) is now handled via a second `CredentialSet`, following the same first-match-wins pattern as SDWAN token/session. This also fixes `validate_controller_env()` automatically covering `IOSXE_HOST`.
 
 ## Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -295,11 +295,13 @@ In addition to Robot Framework, `nac-test` supports PyATS-based tests for networ
 
 PyATS tests support multiple Cisco architectures, each requiring specific environment variables:
 
-| Architecture | Controller | Environment Variables |
-|-------------|------------|----------------------|
+| Architecture | Controller | Credential Sets |
+|-------------|------------|----------------|
 | ACI | APIC | `ACI_URL`, `ACI_USERNAME`, `ACI_PASSWORD` |
-| SD-WAN | SD-WAN Manager | `SDWAN_URL`, `SDWAN_USERNAME`, `SDWAN_PASSWORD` |
+| SD-WAN | SD-WAN Manager | **Token (20.18+):** `SDWAN_URL`, `SDWAN_API_TOKEN` <br> **Or Session:** `SDWAN_URL`, `SDWAN_USERNAME`, `SDWAN_PASSWORD` |
 | Catalyst Center | Catalyst Center | `CC_URL`, `CC_USERNAME`, `CC_PASSWORD` |
+
+> **Note:** SD-WAN supports two credential methods. When both are present, token authentication takes priority. The framework remembers which credential set was matched and exposes the `auth_method` attribute for downstream adapters.
 
 For D2D (Direct-to-Device) SSH tests, IOS-XE device credentials are also required:
 
@@ -322,6 +324,11 @@ PyATS tests are organized into two categories:
 ```bash
 # Set environment variables for your architecture (SD-WAN example)
 export SDWAN_URL=https://sdwan-manager.example.com
+
+# Option 1: API Token authentication (SD-WAN 20.18+)
+export SDWAN_API_TOKEN=your-api-token
+
+# Option 2: Username/Password authentication
 export SDWAN_USERNAME=admin
 export SDWAN_PASSWORD=yourpassword
 
@@ -785,10 +792,12 @@ Simply add `--diagnostic` to your existing nac-test command:
 source .venv/bin/activate
 
 # 2. Set your environment variables (as you normally would for nac-test)
-# Example for SD-WAN:
+# Example for SD-WAN (token auth):
 export SDWAN_URL=https://your-sdwan-manager.example.com
-export SDWAN_USERNAME=admin
-export SDWAN_PASSWORD=your-password
+export SDWAN_API_TOKEN=your-api-token
+# Or username/password auth:
+# export SDWAN_USERNAME=admin
+# export SDWAN_PASSWORD=your-password
 
 # 3. Run nac-test with the --diagnostic flag
 nac-test -d ./data -t ./tests -o ./output --pyats --diagnostic

--- a/dev-docs/PRD_AND_ARCHITECTURE.md
+++ b/dev-docs/PRD_AND_ARCHITECTURE.md
@@ -5781,12 +5781,6 @@ CONTROLLER_REGISTRY: dict[str, ControllerConfig] = {
     ),
     # CC, MERAKI, FMC, ISE, IOSXE follow the same pattern...
 }
-
-# Backward compatibility (uses first credential set per controller)
-CREDENTIAL_PATTERNS: dict[str, list[str]] = {
-    ct: config.credential_sets[0].env_vars
-    for ct, config in CONTROLLER_REGISTRY.items()
-}
 ```
 
 #### Detection Algorithm
@@ -5811,7 +5805,7 @@ def detect_controller_type() -> str:
         detect_controller_type() → "SDWAN"
         get_matched_credential_set("SDWAN").auth_method → "token"
     """
-    complete_sets, partial_sets, matched_creds = _find_credential_sets()
+    complete_sets, partial_controllers, matched_creds = _find_credential_sets()
     # ... validation logic (multiple, none, incomplete) ...
     controller_type = complete_sets[0]
     _matched_credential_sets[controller_type] = matched_creds[controller_type]
@@ -5840,7 +5834,7 @@ flowchart TB
         StoreMatch --> ReturnType[Return controller type]
         CheckSet -->|No| NextSet{More credential_sets?}
         NextSet -->|Yes| IterCreds
-        NextSet -->|No| TrackPartial[Track best partial match]
+        NextSet -->|No| TrackPartial[Track as partial if<br/>any env_var was set]
         TrackPartial --> NextCtrl{More controllers?}
         NextCtrl -->|Yes| ForEach
         NextCtrl -->|No| Validate{Any complete?}

--- a/dev-docs/PRD_AND_ARCHITECTURE.md
+++ b/dev-docs/PRD_AND_ARCHITECTURE.md
@@ -5752,7 +5752,6 @@ class ControllerConfig:
     credential_sets: list[CredentialSet]  # Ordered — first satisfied wins
     defaults_prefix: str
     cache_key: str | None = None
-    alt_url_env_vars: list[str] | None = None
 
 CONTROLLER_REGISTRY: dict[str, ControllerConfig] = {
     "ACI": ControllerConfig(
@@ -5779,7 +5778,17 @@ CONTROLLER_REGISTRY: dict[str, ControllerConfig] = {
         defaults_prefix="defaults.sdwan",
         cache_key="SDWAN_MANAGER",
     ),
-    # CC, MERAKI, FMC, ISE, IOSXE follow the same pattern...
+    "IOSXE": ControllerConfig(
+        display_name="IOS XE",
+        url_env_var="IOSXE_URL",
+        env_var_prefix="IOSXE",
+        credential_sets=[
+            CredentialSet(env_vars=["IOSXE_URL"], label="Device URL"),
+            CredentialSet(env_vars=["IOSXE_HOST"], label="Device Host"),
+        ],
+        defaults_prefix="defaults.iosxe",
+    ),
+    # CC, MERAKI, FMC, ISE follow the same pattern...
 }
 ```
 

--- a/dev-docs/PRD_AND_ARCHITECTURE.md
+++ b/dev-docs/PRD_AND_ARCHITECTURE.md
@@ -5731,46 +5731,100 @@ apic:
 
 nac-test automatically detects the network architecture based on which credential environment variables are set, eliminating the need for users to explicitly set `CONTROLLER_TYPE`.
 
-#### CREDENTIAL_PATTERNS Configuration
+#### CONTROLLER_REGISTRY and CredentialSets
 
 ```python
-# Environment variable patterns for architecture detection
-CREDENTIAL_PATTERNS: dict[str, tuple[str, str, str]] = {
-    # Architecture: (URL_VAR, USERNAME_VAR, PASSWORD_VAR)
-    "aci": ("APIC_URL", "APIC_USERNAME", "APIC_PASSWORD"),
-    "sdwan": ("SDWAN_URL", "SDWAN_USERNAME", "SDWAN_PASSWORD"),
-    "catalyst_center": ("CC_URL", "CC_USERNAME", "CC_PASSWORD"),
-    "meraki": ("MERAKI_URL", "MERAKI_API_KEY", None),  # API key auth
-    "fmc": ("FMC_URL", "FMC_USERNAME", "FMC_PASSWORD"),
-    "ise": ("ISE_URL", "ISE_USERNAME", "ISE_PASSWORD"),
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class CredentialSet:
+    """A single credential combination that can authenticate to a controller."""
+    env_vars: list[str]       # Env vars required for this method
+    label: str                # Human-readable label (e.g., "API Token (20.18+)")
+    auth_method: str = "session"  # Auth mechanism hint for downstream adapters
+
+@dataclass(frozen=True)
+class ControllerConfig:
+    """Configuration metadata for a supported controller type."""
+    display_name: str
+    url_env_var: str
+    env_var_prefix: str
+    credential_sets: list[CredentialSet]  # Ordered — first satisfied wins
+    defaults_prefix: str
+    cache_key: str | None = None
+    alt_url_env_vars: list[str] | None = None
+
+CONTROLLER_REGISTRY: dict[str, ControllerConfig] = {
+    "ACI": ControllerConfig(
+        display_name="APIC",
+        url_env_var="ACI_URL",
+        env_var_prefix="ACI",
+        credential_sets=[
+            CredentialSet(env_vars=["ACI_URL", "ACI_USERNAME", "ACI_PASSWORD"],
+                         label="Username/Password"),
+        ],
+        defaults_prefix="defaults.apic",
+        cache_key="ACI",
+    ),
+    "SDWAN": ControllerConfig(
+        display_name="SDWAN Manager",
+        url_env_var="SDWAN_URL",
+        env_var_prefix="SDWAN",
+        credential_sets=[
+            CredentialSet(env_vars=["SDWAN_URL", "SDWAN_API_TOKEN"],
+                         label="API Token (20.18+)", auth_method="token"),
+            CredentialSet(env_vars=["SDWAN_URL", "SDWAN_USERNAME", "SDWAN_PASSWORD"],
+                         label="Username/Password"),
+        ],
+        defaults_prefix="defaults.sdwan",
+        cache_key="SDWAN_MANAGER",
+    ),
+    # CC, MERAKI, FMC, ISE, IOSXE follow the same pattern...
+}
+
+# Backward compatibility (uses first credential set per controller)
+CREDENTIAL_PATTERNS: dict[str, list[str]] = {
+    ct: config.credential_sets[0].env_vars
+    for ct, config in CONTROLLER_REGISTRY.items()
 }
 ```
 
 #### Detection Algorithm
 
 ```python
-def detect_controller_type() -> str | None:
+def detect_controller_type() -> str:
     """Auto-detect controller type from environment variables.
 
-    Iterates through CREDENTIAL_PATTERNS and returns the first
-    architecture where ALL required credentials are set.
+    Iterates through CONTROLLER_REGISTRY. For each controller, iterates its
+    credential_sets in order. The first CredentialSet whose env_vars are ALL
+    present and non-empty marks the controller as detected. The winning
+    CredentialSet is stored for later retrieval via get_matched_credential_set().
 
     Returns:
-        Architecture name (e.g., "aci", "sdwan") or None if no match
+        Controller type key (e.g., "ACI", "SDWAN")
+
+    Raises:
+        ValueError: If no credentials, multiple controllers, or incomplete credentials
 
     Example:
-        # If APIC_URL, APIC_USERNAME, APIC_PASSWORD are all set:
-        detect_controller_type() → "aci"
+        # If SDWAN_URL and SDWAN_API_TOKEN are set:
+        detect_controller_type() → "SDWAN"
+        get_matched_credential_set("SDWAN").auth_method → "token"
     """
-    for arch, (url_var, user_var, pass_var) in CREDENTIAL_PATTERNS.items():
-        required_vars = [url_var, user_var]
-        if pass_var:  # Some architectures use API keys
-            required_vars.append(pass_var)
+    complete_sets, partial_sets, matched_creds = _find_credential_sets()
+    # ... validation logic (multiple, none, incomplete) ...
+    controller_type = complete_sets[0]
+    _matched_credential_sets[controller_type] = matched_creds[controller_type]
+    return controller_type
 
-        if all(os.environ.get(var) for var in required_vars):
-            return arch
 
-    return None
+def get_matched_credential_set(controller_type: str) -> CredentialSet | None:
+    """Public API for nac-test-pyats-common to retrieve the winning credential set.
+
+    Returns the CredentialSet that was matched during detect_controller_type().
+    The auth_method attribute tells the auth adapter which mechanism to use.
+    """
+    return _matched_credential_sets.get(controller_type)
 ```
 
 #### Detection Flow Diagram
@@ -5778,28 +5832,27 @@ def detect_controller_type() -> str | None:
 ```mermaid
 flowchart TB
     subgraph "Controller Type Detection"
-        Start[Start Detection] --> CheckACI{APIC_URL +<br/>APIC_USERNAME +<br/>APIC_PASSWORD set?}
-        CheckACI -->|Yes| ReturnACI[Return 'aci']
-        CheckACI -->|No| CheckSDWAN{SDWAN_URL +<br/>SDWAN_USERNAME +<br/>SDWAN_PASSWORD set?}
-        CheckSDWAN -->|Yes| ReturnSDWAN[Return 'sdwan']
-        CheckSDWAN -->|No| CheckCC{CC_URL +<br/>CC_USERNAME +<br/>CC_PASSWORD set?}
-        CheckCC -->|Yes| ReturnCC[Return 'catalyst_center']
-        CheckCC -->|No| CheckMeraki{MERAKI_URL +<br/>MERAKI_API_KEY set?}
-        CheckMeraki -->|Yes| ReturnMeraki[Return 'meraki']
-        CheckMeraki -->|No| CheckFMC{FMC_URL +<br/>FMC_USERNAME +<br/>FMC_PASSWORD set?}
-        CheckFMC -->|Yes| ReturnFMC[Return 'fmc']
-        CheckFMC -->|No| CheckISE{ISE_URL +<br/>ISE_USERNAME +<br/>ISE_PASSWORD set?}
-        CheckISE -->|Yes| ReturnISE[Return 'ise']
-        CheckISE -->|No| ReturnNone[Return None]
+        Start[Start Detection] --> IterReg[Iterate CONTROLLER_REGISTRY]
+        IterReg --> ForEach[For each controller]
+        ForEach --> IterCreds[Iterate credential_sets in order]
+        IterCreds --> CheckSet{All env_vars<br/>present & non-empty?}
+        CheckSet -->|Yes| StoreMatch[Store winning CredentialSet<br/>auth_method remembered]
+        StoreMatch --> ReturnType[Return controller type]
+        CheckSet -->|No| NextSet{More credential_sets?}
+        NextSet -->|Yes| IterCreds
+        NextSet -->|No| TrackPartial[Track best partial match]
+        TrackPartial --> NextCtrl{More controllers?}
+        NextCtrl -->|Yes| ForEach
+        NextCtrl -->|No| Validate{Any complete?}
+        Validate -->|None + no partial| ErrNone[Error: No credentials]
+        Validate -->|None + partial| ErrIncomplete[Error: Incomplete credentials]
+        Validate -->|Multiple| ErrMultiple[Error: Multiple controllers]
     end
 
-    style ReturnACI fill:#90EE90
-    style ReturnSDWAN fill:#90EE90
-    style ReturnCC fill:#90EE90
-    style ReturnMeraki fill:#90EE90
-    style ReturnFMC fill:#90EE90
-    style ReturnISE fill:#90EE90
-    style ReturnNone fill:#FFD700
+    style ReturnType fill:#90EE90
+    style ErrNone fill:#FFD700
+    style ErrIncomplete fill:#FFD700
+    style ErrMultiple fill:#FF6347
 ```
 
 #### D2D Tests and Controller Credentials

--- a/nac_test/support/README.md
+++ b/nac_test/support/README.md
@@ -96,10 +96,12 @@ nac-test -d ./data -f ./filters -t ./tests -o ./out --diagnostic
 
 2. Set your environment variables:
    ```bash
-   # For SD-WAN:
+   # For SD-WAN (token auth - 20.18+):
    export SDWAN_URL=https://your-sdwan-manager.example.com
-   export SDWAN_USERNAME=admin
-   export SDWAN_PASSWORD=your-password
+   export SDWAN_API_TOKEN=your-api-token
+   # Or username/password auth:
+   # export SDWAN_USERNAME=admin
+   # export SDWAN_PASSWORD=your-password
    export IOSXE_USERNAME=admin
    export IOSXE_PASSWORD=device-password
 

--- a/nac_test/utils/controller.py
+++ b/nac_test/utils/controller.py
@@ -226,23 +226,7 @@ def detect_controller_type() -> ControllerTypeKey:
 
     # Check for incomplete credentials
     if not complete_sets and partial_controllers:
-        lines_parts: list[str] = []
-        for controller in partial_controllers:
-            config = CONTROLLER_REGISTRY[controller]
-            set_descriptions = [
-                f"{cs.label}: {' + '.join(cs.env_vars)}"
-                for cs in config.credential_sets
-            ]
-            line = f"{controller}: incomplete credentials"
-            line += "\n    Accepted credential sets:\n"
-            line += "\n".join(f"      - {desc}" for desc in set_descriptions)
-            lines_parts.append(line)
-        lines = "\n".join(f"  - {info}" for info in lines_parts)
-        error_message = (
-            f"Incomplete controller credentials detected:\n"
-            f"{lines}\n\n"
-            f"Please provide ALL required environment variables for your controller type."
-        )
+        error_message = _format_incomplete_credentials_error(partial_controllers)
         logger.error(f"Incomplete credentials: {partial_controllers}")
         raise ValueError(error_message)
 
@@ -306,6 +290,45 @@ def _find_credential_sets() -> tuple[list[str], list[str], dict[str, CredentialS
             partial_controllers.append(controller_type)
 
     return complete_sets, partial_controllers, matched_creds
+
+
+def _format_incomplete_credentials_error(partial_controllers: list[str]) -> str:
+    """Format error message for incomplete controller credentials.
+
+    Creates a detailed error message listing each partially configured
+    controller and its accepted credential sets, so the user knows
+    exactly which variables are needed.
+
+    Args:
+        partial_controllers: List of controller types with partial credentials.
+
+    Returns:
+        Formatted error message with accepted credential sets.
+
+    Example:
+        >>> error = _format_incomplete_credentials_error(["SDWAN"])
+        >>> print(error)
+        Incomplete controller credentials detected:
+        ...
+    """
+    lines_parts: list[str] = []
+    for controller in partial_controllers:
+        config = CONTROLLER_REGISTRY[controller]
+        set_descriptions = [
+            f"{cs.label}: {' + '.join(cs.env_vars)}"
+            for cs in config.credential_sets
+        ]
+        line = f"{controller}: incomplete credentials"
+        line += "\n    Accepted credential sets:\n"
+        line += "\n".join(f"      - {desc}" for desc in set_descriptions)
+        lines_parts.append(line)
+    lines = "\n".join(f"  - {info}" for info in lines_parts)
+    return (
+        f"Incomplete controller credentials detected:\n"
+        f"{lines}\n\n"
+        f"Please provide all required variables for one of the "
+        f"accepted credential sets listed above."
+    )
 
 
 def _format_multiple_credentials_error(controllers: list[str]) -> str:

--- a/nac_test/utils/controller.py
+++ b/nac_test/utils/controller.py
@@ -18,6 +18,7 @@ the merged NAC data model.
 
 import logging
 import os
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import cast
 
@@ -215,7 +216,9 @@ def detect_controller_type() -> ControllerTypeKey:
     # Check for multiple complete credential sets
     if len(complete) > 1:
         error_message = _format_multiple_credentials_error(list(complete.keys()))
-        logger.error(f"Multiple controller credentials detected: {list(complete.keys())}")
+        logger.error(
+            f"Multiple controller credentials detected: {list(complete.keys())}"
+        )
         raise ValueError(error_message)
 
     # Check for no credentials at all
@@ -292,7 +295,7 @@ def _find_credential_sets() -> tuple[
     return complete, partial
 
 
-def _format_incomplete_credentials_error(partial_controllers: list[str]) -> str:
+def _format_incomplete_credentials_error(partial_controllers: Sequence[str]) -> str:
     """Format error message for incomplete controller credentials.
 
     Creates a detailed error message listing each partially configured
@@ -315,8 +318,7 @@ def _format_incomplete_credentials_error(partial_controllers: list[str]) -> str:
     for controller in partial_controllers:
         config = CONTROLLER_REGISTRY[controller]
         set_descriptions = [
-            f"{cs.label}: {' + '.join(cs.env_vars)}"
-            for cs in config.credential_sets
+            f"{cs.label}: {' + '.join(cs.env_vars)}" for cs in config.credential_sets
         ]
         line = f"{controller}: incomplete credentials"
         line += "\n    Accepted credential sets:\n"

--- a/nac_test/utils/controller.py
+++ b/nac_test/utils/controller.py
@@ -61,8 +61,6 @@ class ControllerConfig:
             (e.g., "defaults.apic", "defaults.sdwan").
         cache_key: The controller_type string passed to AuthCache by the auth adapter.
             None for controllers that don't have an auth adapter in nac-test-pyats-common.
-        alt_url_env_vars: Alternative environment variable names for the URL.
-            Used when a controller supports multiple URL env var names (e.g., IOSXE_HOST).
     """
 
     display_name: str
@@ -71,7 +69,6 @@ class ControllerConfig:
     credential_sets: list[CredentialSet]
     defaults_prefix: str
     cache_key: str | None = None
-    alt_url_env_vars: list[str] | None = None
 
 
 # Single source of truth for all controller configurations
@@ -167,9 +164,12 @@ CONTROLLER_REGISTRY: dict[str, ControllerConfig] = {
                 env_vars=["IOSXE_URL"],
                 label="Device URL",
             ),
+            CredentialSet(
+                env_vars=["IOSXE_HOST"],
+                label="Device Host",
+            ),
         ],
         defaults_prefix="defaults.iosxe",
-        alt_url_env_vars=["IOSXE_HOST"],  # Alternative env var for URL
     ),
 }
 
@@ -270,9 +270,6 @@ def _find_credential_sets() -> tuple[list[str], list[str], dict[str, CredentialS
     complete. If no set is fully satisfied but at least one variable from any set
     is present, the controller is reported as partial.
 
-    This function also handles alternative URL environment variables (e.g., IOSXE_HOST
-    as an alternative to IOSXE_URL) when configured in the ControllerConfig.
-
     Returns:
         A tuple containing:
             - List of controller types with complete credentials
@@ -296,21 +293,7 @@ def _find_credential_sets() -> tuple[list[str], list[str], dict[str, CredentialS
                     has_any_var = True
                     logger.debug(f"  {controller_type}: Found {var}")
                 else:
-                    # Check alternative URL env vars if this is the URL variable
-                    alt_found = False
-                    if var == config.url_env_var and config.alt_url_env_vars:
-                        for alt_var in config.alt_url_env_vars:
-                            alt_value = os.environ.get(alt_var)
-                            if alt_value and alt_value.strip():
-                                has_any_var = True
-                                logger.debug(
-                                    f"  {controller_type}: Found {alt_var} (alternative)"
-                                )
-                                alt_found = True
-                                break
-
-                    if not alt_found:
-                        all_present = False
+                    all_present = False
 
             if all_present:
                 complete_sets.append(controller_type)
@@ -491,9 +474,8 @@ def get_defaults_prefix(controller_type: str) -> str:
 def get_controller_url(controller_type: str) -> str:
     """Get the controller URL from environment variables.
 
-    Looks up the primary URL environment variable from CONTROLLER_REGISTRY, and
-    also checks alternative URL env vars if configured (e.g., IOSXE_HOST as an
-    alternative to IOSXE_URL).
+    Iterates through credential sets in order, returning the first env var value
+    found. This follows the same first-match-wins pattern as _find_credential_sets.
 
     Args:
         controller_type: The internal controller type key (e.g., "ACI", "SDWAN", "IOSXE").
@@ -502,7 +484,7 @@ def get_controller_url(controller_type: str) -> str:
         The controller URL value from the environment.
 
     Raises:
-        KeyError: If neither the primary nor any alternative URL env var is set.
+        KeyError: If no credential set env var has a URL value set.
 
     Example:
         >>> os.environ["ACI_URL"] = "https://apic.example.com"
@@ -519,17 +501,12 @@ def get_controller_url(controller_type: str) -> str:
         # Fallback for unknown controller types
         return os.environ[f"{controller_type}_URL"]
 
-    # Try primary URL env var first
-    url_value = os.environ.get(config.url_env_var)
-    if url_value and url_value.strip():
-        return url_value.strip()
-
-    # Try alternative URL env vars if configured
-    if config.alt_url_env_vars:
-        for alt_var in config.alt_url_env_vars:
-            alt_value = os.environ.get(alt_var)
-            if alt_value and alt_value.strip():
-                return alt_value.strip()
+    # Iterate credential sets — first env var with a value wins
+    for cred_set in config.credential_sets:
+        for var in cred_set.env_vars:
+            value = os.environ.get(var)
+            if value and value.strip():
+                return value.strip()
 
     # No URL found - raise KeyError with the primary var name
     raise KeyError(config.url_env_var)

--- a/nac_test/utils/controller.py
+++ b/nac_test/utils/controller.py
@@ -39,6 +39,23 @@ class CredentialSetStatus(TypedDict):
 
 
 @dataclass(frozen=True)
+class CredentialSet:
+    """A single credential combination that can authenticate to a controller.
+
+    Each set is self-contained: if ALL env_vars are present and non-empty,
+    the controller is considered fully configured. When a controller has
+    multiple CredentialSets, the first satisfied set wins (order matters).
+
+    Attributes:
+        env_vars: Environment variable names required for this credential method.
+        label: Human-readable label for error messages (e.g., "API Token (20.18+)").
+    """
+
+    env_vars: list[str]
+    label: str
+
+
+@dataclass(frozen=True)
 class ControllerConfig:
     """Configuration metadata for a supported controller type.
 
@@ -46,7 +63,9 @@ class ControllerConfig:
         display_name: User-facing name (e.g., "APIC", "Catalyst Center").
         url_env_var: Environment variable name for the controller URL.
         env_var_prefix: Prefix for credential env vars (e.g., "ACI" → ACI_USERNAME).
-        required_env_vars: List of environment variables required for this controller.
+        credential_sets: Ordered list of credential combinations. The first set
+            whose env_vars are all present and non-empty wins. Every controller
+            must have at least one CredentialSet.
         defaults_prefix: JMESPath prefix for the defaults block in NAC data models
             (e.g., "defaults.apic", "defaults.sdwan").
         cache_key: The controller_type string passed to AuthCache by the auth adapter.
@@ -58,7 +77,7 @@ class ControllerConfig:
     display_name: str
     url_env_var: str
     env_var_prefix: str
-    required_env_vars: list[str]
+    credential_sets: list[CredentialSet]
     defaults_prefix: str
     cache_key: str | None = None
     alt_url_env_vars: list[str] | None = None
@@ -71,7 +90,12 @@ CONTROLLER_REGISTRY: dict[str, ControllerConfig] = {
         display_name="APIC",
         url_env_var="ACI_URL",
         env_var_prefix="ACI",
-        required_env_vars=["ACI_URL", "ACI_USERNAME", "ACI_PASSWORD"],
+        credential_sets=[
+            CredentialSet(
+                env_vars=["ACI_URL", "ACI_USERNAME", "ACI_PASSWORD"],
+                label="Username/Password",
+            ),
+        ],
         defaults_prefix="defaults.apic",
         cache_key="ACI",
     ),
@@ -79,7 +103,16 @@ CONTROLLER_REGISTRY: dict[str, ControllerConfig] = {
         display_name="SDWAN Manager",
         url_env_var="SDWAN_URL",
         env_var_prefix="SDWAN",
-        required_env_vars=["SDWAN_URL", "SDWAN_USERNAME", "SDWAN_PASSWORD"],
+        credential_sets=[
+            CredentialSet(
+                env_vars=["SDWAN_URL", "SDWAN_API_TOKEN"],
+                label="API Token (20.18+)",
+            ),
+            CredentialSet(
+                env_vars=["SDWAN_URL", "SDWAN_USERNAME", "SDWAN_PASSWORD"],
+                label="Username/Password",
+            ),
+        ],
         defaults_prefix="defaults.sdwan",
         cache_key="SDWAN_MANAGER",
     ),
@@ -87,7 +120,12 @@ CONTROLLER_REGISTRY: dict[str, ControllerConfig] = {
         display_name="Catalyst Center",
         url_env_var="CC_URL",
         env_var_prefix="CC",
-        required_env_vars=["CC_URL", "CC_USERNAME", "CC_PASSWORD"],
+        credential_sets=[
+            CredentialSet(
+                env_vars=["CC_URL", "CC_USERNAME", "CC_PASSWORD"],
+                label="Username/Password",
+            ),
+        ],
         defaults_prefix="defaults.catc",
         cache_key="CC",
     ),
@@ -95,38 +133,58 @@ CONTROLLER_REGISTRY: dict[str, ControllerConfig] = {
         display_name="Meraki",
         url_env_var="MERAKI_URL",
         env_var_prefix="MERAKI",
-        required_env_vars=["MERAKI_URL", "MERAKI_USERNAME", "MERAKI_PASSWORD"],
+        credential_sets=[
+            CredentialSet(
+                env_vars=["MERAKI_URL", "MERAKI_USERNAME", "MERAKI_PASSWORD"],
+                label="Username/Password",
+            ),
+        ],
         defaults_prefix="defaults.meraki",
     ),
     "FMC": ControllerConfig(
         display_name="Firepower Management Center",
         url_env_var="FMC_URL",
         env_var_prefix="FMC",
-        required_env_vars=["FMC_URL", "FMC_USERNAME", "FMC_PASSWORD"],
+        credential_sets=[
+            CredentialSet(
+                env_vars=["FMC_URL", "FMC_USERNAME", "FMC_PASSWORD"],
+                label="Username/Password",
+            ),
+        ],
         defaults_prefix="defaults.fmc",
     ),
     "ISE": ControllerConfig(
         display_name="ISE",
         url_env_var="ISE_URL",
         env_var_prefix="ISE",
-        required_env_vars=["ISE_URL", "ISE_USERNAME", "ISE_PASSWORD"],
+        credential_sets=[
+            CredentialSet(
+                env_vars=["ISE_URL", "ISE_USERNAME", "ISE_PASSWORD"],
+                label="Username/Password",
+            ),
+        ],
         defaults_prefix="defaults.ise",
     ),
     "IOSXE": ControllerConfig(
         display_name="IOS XE",
         url_env_var="IOSXE_URL",
         env_var_prefix="IOSXE",
-        required_env_vars=[
-            "IOSXE_URL"
-        ],  # Direct device access, no controller credentials
+        # Direct device access, no controller credentials required
+        credential_sets=[
+            CredentialSet(
+                env_vars=["IOSXE_URL"],
+                label="Device URL",
+            ),
+        ],
         defaults_prefix="defaults.iosxe",
         alt_url_env_vars=["IOSXE_HOST"],  # Alternative env var for URL
     ),
 }
 
 # Backward compatibility - remove in future version
+# Uses the first credential set's env_vars as the "primary" pattern
 CREDENTIAL_PATTERNS: dict[str, list[str]] = {
-    controller_type: config.required_env_vars
+    controller_type: config.credential_sets[0].env_vars
     for controller_type, config in CONTROLLER_REGISTRY.items()
 }
 
@@ -158,7 +216,7 @@ def detect_controller_type() -> ControllerTypeKey:
         "ACI"
     """
     logger.debug("Starting controller type detection")
-    logger.debug(f"Checking for credentials: {list(CREDENTIAL_PATTERNS.keys())}")
+    logger.debug(f"Checking for credentials: {list(CONTROLLER_REGISTRY.keys())}")
 
     complete_sets, partial_sets = _find_credential_sets()
 
@@ -179,10 +237,19 @@ def detect_controller_type() -> ControllerTypeKey:
 
     # Check for incomplete credentials
     if not complete_sets and partial_sets:
-        incomplete_info = [
-            f"{controller}: missing {', '.join(info['missing'])}"
-            for controller, info in partial_sets.items()
-        ]
+        incomplete_info = []
+        for controller, info in partial_sets.items():
+            line = f"{controller}: missing {', '.join(info['missing'])}"
+            # Show all credential set options for this controller
+            config = CONTROLLER_REGISTRY.get(controller)
+            if config and len(config.credential_sets) > 1:
+                set_descriptions = [
+                    f"{cs.label}: {' + '.join(cs.env_vars)}"
+                    for cs in config.credential_sets
+                ]
+                line += "\n    Accepted credential sets:\n"
+                line += "\n".join(f"      - {desc}" for desc in set_descriptions)
+            incomplete_info.append(line)
         lines = "\n".join(f"  - {info}" for info in incomplete_info)
         error_message = (
             f"Incomplete controller credentials detected:\n"
@@ -206,6 +273,11 @@ def _find_credential_sets() -> tuple[list[str], dict[str, CredentialSetStatus]]:
     Examines environment variables to identify which controller types have
     complete credentials configured and which have partial/incomplete credentials.
 
+    For each controller, iterates through its credential_sets in order. The first
+    set whose env_vars are all present and non-empty marks the controller as
+    complete. If no set is fully satisfied but at least one variable from any set
+    is present, the controller is reported as partial (using the best partial match).
+
     This function also handles alternative URL environment variables (e.g., IOSXE_HOST
     as an alternative to IOSXE_URL) when configured in the ControllerConfig.
 
@@ -226,45 +298,58 @@ def _find_credential_sets() -> tuple[list[str], dict[str, CredentialSetStatus]]:
     partial_sets: dict[str, CredentialSetStatus] = {}
 
     for controller_type, config in CONTROLLER_REGISTRY.items():
-        required_vars = config.required_env_vars
-        present_vars = []
-        missing_vars = []
+        best_present: list[str] = []
+        best_missing: list[str] = []
+        found_complete = False
 
-        for var in required_vars:
-            # Check if variable exists AND is not empty
-            value = os.environ.get(var)
-            if value and value.strip():  # Non-empty value
-                present_vars.append(var)
-                logger.debug(f"  {controller_type}: Found {var}")
-            else:
-                # Check alternative URL env vars if this is the URL variable
-                alt_found = False
-                if var == config.url_env_var and config.alt_url_env_vars:
-                    for alt_var in config.alt_url_env_vars:
-                        alt_value = os.environ.get(alt_var)
-                        if alt_value and alt_value.strip():
-                            present_vars.append(alt_var)
-                            logger.debug(
-                                f"  {controller_type}: Found {alt_var} (alternative)"
-                            )
-                            alt_found = True
-                            break
+        for cred_set in config.credential_sets:
+            present_vars: list[str] = []
+            missing_vars: list[str] = []
 
-                if not alt_found:
-                    missing_vars.append(var)
-                    if var in os.environ:
-                        logger.debug(f"  {controller_type}: Empty {var}")
-                    else:
-                        logger.debug(f"  {controller_type}: Missing {var}")
+            for var in cred_set.env_vars:
+                value = os.environ.get(var)
+                if value and value.strip():
+                    present_vars.append(var)
+                    logger.debug(f"  {controller_type}: Found {var}")
+                else:
+                    # Check alternative URL env vars if this is the URL variable
+                    alt_found = False
+                    if var == config.url_env_var and config.alt_url_env_vars:
+                        for alt_var in config.alt_url_env_vars:
+                            alt_value = os.environ.get(alt_var)
+                            if alt_value and alt_value.strip():
+                                present_vars.append(alt_var)
+                                logger.debug(
+                                    f"  {controller_type}: Found {alt_var} (alternative)"
+                                )
+                                alt_found = True
+                                break
 
-        if present_vars and not missing_vars:
-            # All required variables present and non-empty
-            complete_sets.append(controller_type)
-        elif present_vars:
-            # Some but not all variables present
+                    if not alt_found:
+                        missing_vars.append(var)
+                        if var in os.environ:
+                            logger.debug(f"  {controller_type}: Empty {var}")
+                        else:
+                            logger.debug(f"  {controller_type}: Missing {var}")
+
+            if present_vars and not missing_vars:
+                # This credential set is fully satisfied — first wins
+                complete_sets.append(controller_type)
+                logger.debug(
+                    f"  {controller_type}: Complete via {cred_set.label}"
+                )
+                found_complete = True
+                break
+
+            # Track the best partial match (most present vars)
+            if len(present_vars) > len(best_present):
+                best_present = present_vars
+                best_missing = missing_vars
+
+        if not found_complete and best_present:
             partial_sets[controller_type] = {
-                "present": present_vars,
-                "missing": missing_vars,
+                "present": best_present,
+                "missing": best_missing,
             }
 
     return complete_sets, partial_sets
@@ -290,11 +375,6 @@ def _format_multiple_credentials_error(controllers: list[str]) -> str:
     """
     controller_list = ", ".join(controllers)
 
-    # Build list of all environment variables that should be unset
-    vars_to_unset: list[str] = []
-    for controller in controllers:
-        vars_to_unset.extend(CREDENTIAL_PATTERNS[controller])
-
     message = (
         f"Multiple controller credentials detected: {controller_list}\n\n"
         f"The test framework requires exactly one controller type to be configured.\n\n"
@@ -302,12 +382,26 @@ def _format_multiple_credentials_error(controllers: list[str]) -> str:
         f"1. Keep only one controller's credentials and unset the others:\n"
     )
 
+    # Collect all env vars per controller (union of all credential sets)
+    def _all_env_vars(controller: str) -> list[str]:
+        config = CONTROLLER_REGISTRY.get(controller)
+        if not config:
+            return CREDENTIAL_PATTERNS.get(controller, [])
+        seen: set[str] = set()
+        result: list[str] = []
+        for cs in config.credential_sets:
+            for v in cs.env_vars:
+                if v not in seen:
+                    seen.add(v)
+                    result.append(v)
+        return result
+
     # Add specific unset commands for each controller
     for controller in controllers:
         other_controllers = [c for c in controllers if c != controller]
         vars_to_remove = []
         for other in other_controllers:
-            vars_to_remove.extend(CREDENTIAL_PATTERNS[other])
+            vars_to_remove.extend(_all_env_vars(other))
 
         unset_command = f"   unset {' '.join(vars_to_remove)}"
         message += f"\n   To use {controller} only:\n{unset_command}\n"
@@ -342,10 +436,15 @@ def _format_no_credentials_error() -> str:
         "Please set environment variables for ONE of the following controller types:\n\n"
     )
 
-    for controller_type, required_vars in CREDENTIAL_PATTERNS.items():
+    for controller_type, config in CONTROLLER_REGISTRY.items():
         message += f"{controller_type}:\n"
-        for var in required_vars:
-            message += f"  export {var}=<value>\n"
+        for i, cred_set in enumerate(config.credential_sets):
+            if i > 0:
+                message += "  Or\n"
+            if len(config.credential_sets) > 1:
+                message += f"  ({cred_set.label}):\n"
+            for var in cred_set.env_vars:
+                message += f"  export {var}=<value>\n"
         message += "\n"
 
     message += (

--- a/nac_test/utils/controller.py
+++ b/nac_test/utils/controller.py
@@ -161,11 +161,11 @@ CONTROLLER_REGISTRY: dict[str, ControllerConfig] = {
         # Direct device access, no controller credentials required
         credential_sets=(
             CredentialSet(
-                env_vars=("IOSXE_URL",),
+                env_vars=("IOSXE_URL", "IOSXE_USERNAME", "IOSXE_PASSWORD"),
                 label="Device URL",
             ),
             CredentialSet(
-                env_vars=("IOSXE_HOST",),
+                env_vars=("IOSXE_HOST", "IOSXE_USERNAME", "IOSXE_PASSWORD"),
                 label="Device Host",
             ),
         ),

--- a/nac_test/utils/controller.py
+++ b/nac_test/utils/controller.py
@@ -41,7 +41,7 @@ class CredentialSet:
             to select the authentication mechanism (e.g., "token", "session").
     """
 
-    env_vars: list[str]
+    env_vars: tuple[str, ...]
     label: str
     auth_method: str = "session"
 
@@ -66,7 +66,7 @@ class ControllerConfig:
     display_name: str
     url_env_var: str
     env_var_prefix: str
-    credential_sets: list[CredentialSet]
+    credential_sets: tuple[CredentialSet, ...]
     defaults_prefix: str
     cache_key: str | None = None
 
@@ -78,12 +78,12 @@ CONTROLLER_REGISTRY: dict[str, ControllerConfig] = {
         display_name="APIC",
         url_env_var="ACI_URL",
         env_var_prefix="ACI",
-        credential_sets=[
+        credential_sets=(
             CredentialSet(
-                env_vars=["ACI_URL", "ACI_USERNAME", "ACI_PASSWORD"],
+                env_vars=("ACI_URL", "ACI_USERNAME", "ACI_PASSWORD"),
                 label="Username/Password",
             ),
-        ],
+        ),
         defaults_prefix="defaults.apic",
         cache_key="ACI",
     ),
@@ -91,17 +91,17 @@ CONTROLLER_REGISTRY: dict[str, ControllerConfig] = {
         display_name="SDWAN Manager",
         url_env_var="SDWAN_URL",
         env_var_prefix="SDWAN",
-        credential_sets=[
+        credential_sets=(
             CredentialSet(
-                env_vars=["SDWAN_URL", "SDWAN_API_TOKEN"],
+                env_vars=("SDWAN_URL", "SDWAN_API_TOKEN"),
                 label="API Token (20.18+)",
                 auth_method="token",
             ),
             CredentialSet(
-                env_vars=["SDWAN_URL", "SDWAN_USERNAME", "SDWAN_PASSWORD"],
+                env_vars=("SDWAN_URL", "SDWAN_USERNAME", "SDWAN_PASSWORD"),
                 label="Username/Password",
             ),
-        ],
+        ),
         defaults_prefix="defaults.sdwan",
         cache_key="SDWAN_MANAGER",
     ),
@@ -109,12 +109,12 @@ CONTROLLER_REGISTRY: dict[str, ControllerConfig] = {
         display_name="Catalyst Center",
         url_env_var="CC_URL",
         env_var_prefix="CC",
-        credential_sets=[
+        credential_sets=(
             CredentialSet(
-                env_vars=["CC_URL", "CC_USERNAME", "CC_PASSWORD"],
+                env_vars=("CC_URL", "CC_USERNAME", "CC_PASSWORD"),
                 label="Username/Password",
             ),
-        ],
+        ),
         defaults_prefix="defaults.catc",
         cache_key="CC",
     ),
@@ -122,36 +122,36 @@ CONTROLLER_REGISTRY: dict[str, ControllerConfig] = {
         display_name="Meraki",
         url_env_var="MERAKI_URL",
         env_var_prefix="MERAKI",
-        credential_sets=[
+        credential_sets=(
             CredentialSet(
-                env_vars=["MERAKI_URL", "MERAKI_USERNAME", "MERAKI_PASSWORD"],
+                env_vars=("MERAKI_URL", "MERAKI_USERNAME", "MERAKI_PASSWORD"),
                 label="Username/Password",
             ),
-        ],
+        ),
         defaults_prefix="defaults.meraki",
     ),
     "FMC": ControllerConfig(
         display_name="Firepower Management Center",
         url_env_var="FMC_URL",
         env_var_prefix="FMC",
-        credential_sets=[
+        credential_sets=(
             CredentialSet(
-                env_vars=["FMC_URL", "FMC_USERNAME", "FMC_PASSWORD"],
+                env_vars=("FMC_URL", "FMC_USERNAME", "FMC_PASSWORD"),
                 label="Username/Password",
             ),
-        ],
+        ),
         defaults_prefix="defaults.fmc",
     ),
     "ISE": ControllerConfig(
         display_name="ISE",
         url_env_var="ISE_URL",
         env_var_prefix="ISE",
-        credential_sets=[
+        credential_sets=(
             CredentialSet(
-                env_vars=["ISE_URL", "ISE_USERNAME", "ISE_PASSWORD"],
+                env_vars=("ISE_URL", "ISE_USERNAME", "ISE_PASSWORD"),
                 label="Username/Password",
             ),
-        ],
+        ),
         defaults_prefix="defaults.ise",
     ),
     "IOSXE": ControllerConfig(
@@ -159,16 +159,16 @@ CONTROLLER_REGISTRY: dict[str, ControllerConfig] = {
         url_env_var="IOSXE_URL",
         env_var_prefix="IOSXE",
         # Direct device access, no controller credentials required
-        credential_sets=[
+        credential_sets=(
             CredentialSet(
-                env_vars=["IOSXE_URL"],
+                env_vars=("IOSXE_URL",),
                 label="Device URL",
             ),
             CredentialSet(
-                env_vars=["IOSXE_HOST"],
+                env_vars=("IOSXE_HOST",),
                 label="Device Host",
             ),
-        ],
+        ),
         defaults_prefix="defaults.iosxe",
     ),
 }

--- a/nac_test/utils/controller.py
+++ b/nac_test/utils/controller.py
@@ -19,23 +19,11 @@ the merged NAC data model.
 import logging
 import os
 from dataclasses import dataclass
-from typing import TypedDict, cast
+from typing import cast
 
 from nac_test.core.types import ControllerTypeKey
 
 logger = logging.getLogger(__name__)
-
-
-class CredentialSetStatus(TypedDict):
-    """Status of a controller credential set.
-
-    Attributes:
-        present: List of environment variable names that are set.
-        missing: List of environment variable names that are not set.
-    """
-
-    present: list[str]
-    missing: list[str]
 
 
 @dataclass(frozen=True)
@@ -219,10 +207,10 @@ def detect_controller_type() -> ControllerTypeKey:
     logger.debug("Starting controller type detection")
     logger.debug(f"Checking for credentials: {list(CONTROLLER_REGISTRY.keys())}")
 
-    complete_sets, partial_sets, matched_creds = _find_credential_sets()
+    complete_sets, partial_controllers, matched_creds = _find_credential_sets()
 
     logger.debug(f"Complete credential sets found: {complete_sets}")
-    logger.debug(f"Partial credential sets found: {list(partial_sets.keys())}")
+    logger.debug(f"Partial credential sets found: {partial_controllers}")
 
     # Check for multiple complete credential sets
     if len(complete_sets) > 1:
@@ -231,33 +219,31 @@ def detect_controller_type() -> ControllerTypeKey:
         raise ValueError(error_message)
 
     # Check for no credentials at all
-    if not complete_sets and not partial_sets:
+    if not complete_sets and not partial_controllers:
         error_message = _format_no_credentials_error()
         logger.error("No controller credentials found in environment")
         raise ValueError(error_message)
 
     # Check for incomplete credentials
-    if not complete_sets and partial_sets:
-        incomplete_info = []
-        for controller, info in partial_sets.items():
-            line = f"{controller}: missing {', '.join(info['missing'])}"
-            # Show all credential set options for this controller
-            config = CONTROLLER_REGISTRY.get(controller)
-            if config and len(config.credential_sets) > 1:
-                set_descriptions = [
-                    f"{cs.label}: {' + '.join(cs.env_vars)}"
-                    for cs in config.credential_sets
-                ]
-                line += "\n    Accepted credential sets:\n"
-                line += "\n".join(f"      - {desc}" for desc in set_descriptions)
-            incomplete_info.append(line)
-        lines = "\n".join(f"  - {info}" for info in incomplete_info)
+    if not complete_sets and partial_controllers:
+        lines_parts: list[str] = []
+        for controller in partial_controllers:
+            config = CONTROLLER_REGISTRY[controller]
+            set_descriptions = [
+                f"{cs.label}: {' + '.join(cs.env_vars)}"
+                for cs in config.credential_sets
+            ]
+            line = f"{controller}: incomplete credentials"
+            line += "\n    Accepted credential sets:\n"
+            line += "\n".join(f"      - {desc}" for desc in set_descriptions)
+            lines_parts.append(line)
+        lines = "\n".join(f"  - {info}" for info in lines_parts)
         error_message = (
             f"Incomplete controller credentials detected:\n"
             f"{lines}\n\n"
             f"Please provide ALL required environment variables for your controller type."
         )
-        logger.error(f"Incomplete credentials: {partial_sets}")
+        logger.error(f"Incomplete credentials: {partial_controllers}")
         raise ValueError(error_message)
 
     # Exactly one complete set found - success
@@ -276,18 +262,13 @@ def detect_controller_type() -> ControllerTypeKey:
     return controller_type
 
 
-def _find_credential_sets() -> tuple[
-    list[str], dict[str, CredentialSetStatus], dict[str, CredentialSet]
-]:
+def _find_credential_sets() -> tuple[list[str], list[str], dict[str, CredentialSet]]:
     """Find complete and partial credential sets in environment.
-
-    Examines environment variables to identify which controller types have
-    complete credentials configured and which have partial/incomplete credentials.
 
     For each controller, iterates through its credential_sets in order. The first
     set whose env_vars are all present and non-empty marks the controller as
     complete. If no set is fully satisfied but at least one variable from any set
-    is present, the controller is reported as partial (using the best partial match).
+    is present, the controller is reported as partial.
 
     This function also handles alternative URL environment variables (e.g., IOSXE_HOST
     as an alternative to IOSXE_URL) when configured in the ControllerConfig.
@@ -295,34 +276,24 @@ def _find_credential_sets() -> tuple[
     Returns:
         A tuple containing:
             - List of controller types with complete credentials
-            - Dictionary mapping controller types to CredentialSetStatus
+            - List of controller types with partial credentials
             - Dictionary mapping controller types to the winning CredentialSet
-
-    Example:
-        >>> os.environ.update({"ACI_URL": "https://apic.local", "ACI_USERNAME": "admin"})
-        >>> complete, partial, matched = _find_credential_sets()
-        >>> print(complete)
-        []
-        >>> print(partial)
-        {"ACI": {"present": ["ACI_URL", "ACI_USERNAME"], "missing": ["ACI_PASSWORD"]}}
     """
     complete_sets: list[str] = []
-    partial_sets: dict[str, CredentialSetStatus] = {}
+    partial_controllers: list[str] = []
     matched_creds: dict[str, CredentialSet] = {}
 
     for controller_type, config in CONTROLLER_REGISTRY.items():
-        best_present: list[str] = []
-        best_missing: list[str] = []
         found_complete = False
+        has_any_var = False
 
         for cred_set in config.credential_sets:
-            present_vars: list[str] = []
-            missing_vars: list[str] = []
+            all_present = True
 
             for var in cred_set.env_vars:
                 value = os.environ.get(var)
                 if value and value.strip():
-                    present_vars.append(var)
+                    has_any_var = True
                     logger.debug(f"  {controller_type}: Found {var}")
                 else:
                     # Check alternative URL env vars if this is the URL variable
@@ -331,7 +302,7 @@ def _find_credential_sets() -> tuple[
                         for alt_var in config.alt_url_env_vars:
                             alt_value = os.environ.get(alt_var)
                             if alt_value and alt_value.strip():
-                                present_vars.append(alt_var)
+                                has_any_var = True
                                 logger.debug(
                                     f"  {controller_type}: Found {alt_var} (alternative)"
                                 )
@@ -339,32 +310,19 @@ def _find_credential_sets() -> tuple[
                                 break
 
                     if not alt_found:
-                        missing_vars.append(var)
-                        if var in os.environ:
-                            logger.debug(f"  {controller_type}: Empty {var}")
-                        else:
-                            logger.debug(f"  {controller_type}: Missing {var}")
+                        all_present = False
 
-            if present_vars and not missing_vars:
-                # This credential set is fully satisfied — first wins
+            if all_present:
                 complete_sets.append(controller_type)
                 matched_creds[controller_type] = cred_set
                 logger.debug(f"  {controller_type}: Complete via {cred_set.label}")
                 found_complete = True
                 break
 
-            # Track the best partial match (most present vars)
-            if len(present_vars) > len(best_present):
-                best_present = present_vars
-                best_missing = missing_vars
+        if not found_complete and has_any_var:
+            partial_controllers.append(controller_type)
 
-        if not found_complete and best_present:
-            partial_sets[controller_type] = {
-                "present": best_present,
-                "missing": best_missing,
-            }
-
-    return complete_sets, partial_sets, matched_creds
+    return complete_sets, partial_controllers, matched_creds
 
 
 def _format_multiple_credentials_error(controllers: list[str]) -> str:

--- a/nac_test/utils/controller.py
+++ b/nac_test/utils/controller.py
@@ -524,13 +524,18 @@ def get_controller_url(controller_type: str) -> str:
         # Fallback for unknown controller types
         return os.environ[f"{controller_type}_URL"]
 
-    # Iterate credential sets — first env var with a value wins
-    for cred_set in config.credential_sets:
-        for var in cred_set.env_vars:
-            if _is_env_var_set(var):
-                return os.environ[var].strip()
+    # Primary URL from the explicit url_env_var field
+    value = os.environ.get(config.url_env_var, "").strip()
+    if value:
+        return value
 
-    # No URL found - raise KeyError with the primary var name
+    # Fallback for alternative URL vars (e.g., IOSXE_HOST)
+    for cred_set in config.credential_sets:
+        if cred_set.env_vars[0] != config.url_env_var:
+            alt = os.environ.get(cred_set.env_vars[0], "").strip()
+            if alt:
+                return alt
+
     raise KeyError(config.url_env_var)
 
 

--- a/nac_test/utils/controller.py
+++ b/nac_test/utils/controller.py
@@ -240,6 +240,12 @@ def detect_controller_type() -> ControllerTypeKey:
     return controller_type
 
 
+def _is_env_var_set(var: str) -> bool:
+    """Check if env var exists and has a non-whitespace value."""
+    value = os.environ.get(var)
+    return bool(value and value.strip())
+
+
 def _find_credential_sets() -> tuple[
     dict[ControllerTypeKey, CredentialSet],
     list[ControllerTypeKey],
@@ -268,8 +274,7 @@ def _find_credential_sets() -> tuple[
             all_present = True
 
             for var in cred_set.env_vars:
-                value = os.environ.get(var)
-                if value and value.strip():
+                if _is_env_var_set(var):
                     has_any_var = True
                     logger.debug(f"  {controller_type}: Found {var}")
                 else:
@@ -522,9 +527,8 @@ def get_controller_url(controller_type: str) -> str:
     # Iterate credential sets — first env var with a value wins
     for cred_set in config.credential_sets:
         for var in cred_set.env_vars:
-            value = os.environ.get(var)
-            if value and value.strip():
-                return value.strip()
+            if _is_env_var_set(var):
+                return os.environ[var].strip()
 
     # No URL found - raise KeyError with the primary var name
     raise KeyError(config.url_env_var)

--- a/nac_test/utils/controller.py
+++ b/nac_test/utils/controller.py
@@ -49,10 +49,13 @@ class CredentialSet:
     Attributes:
         env_vars: Environment variable names required for this credential method.
         label: Human-readable label for error messages (e.g., "API Token (20.18+)").
+        auth_method: Identifier consumed by auth adapters in nac-test-pyats-common
+            to select the authentication mechanism (e.g., "token", "session").
     """
 
     env_vars: list[str]
     label: str
+    auth_method: str = "session"
 
 
 @dataclass(frozen=True)
@@ -107,6 +110,7 @@ CONTROLLER_REGISTRY: dict[str, ControllerConfig] = {
             CredentialSet(
                 env_vars=["SDWAN_URL", "SDWAN_API_TOKEN"],
                 label="API Token (20.18+)",
+                auth_method="token",
             ),
             CredentialSet(
                 env_vars=["SDWAN_URL", "SDWAN_USERNAME", "SDWAN_PASSWORD"],
@@ -188,6 +192,10 @@ CREDENTIAL_PATTERNS: dict[str, list[str]] = {
     for controller_type, config in CONTROLLER_REGISTRY.items()
 }
 
+# Module-level cache for the credential set that was matched during detection.
+# Populated by detect_controller_type(), consumed by get_matched_credential_set().
+_matched_credential_sets: dict[str, CredentialSet] = {}
+
 
 def detect_controller_type() -> ControllerTypeKey:
     """Detect the controller type based on environment variables.
@@ -218,7 +226,7 @@ def detect_controller_type() -> ControllerTypeKey:
     logger.debug("Starting controller type detection")
     logger.debug(f"Checking for credentials: {list(CONTROLLER_REGISTRY.keys())}")
 
-    complete_sets, partial_sets = _find_credential_sets()
+    complete_sets, partial_sets, matched_creds = _find_credential_sets()
 
     logger.debug(f"Complete credential sets found: {complete_sets}")
     logger.debug(f"Partial credential sets found: {list(partial_sets.keys())}")
@@ -263,11 +271,21 @@ def detect_controller_type() -> ControllerTypeKey:
     # complete_sets come from CONTROLLER_REGISTRY keys, which are always valid
     # ControllerTypeKey values, but mypy can't infer this from dict iteration.
     controller_type = cast(ControllerTypeKey, complete_sets[0])
-    logger.info(f"Detected controller type: {controller_type}")
+    # Store the winning credential set for retrieval by auth adapters
+    if controller_type in matched_creds:
+        _matched_credential_sets[controller_type] = matched_creds[controller_type]
+        logger.info(
+            f"Detected controller type: {controller_type} "
+            f"(auth_method={matched_creds[controller_type].auth_method})"
+        )
+    else:
+        logger.info(f"Detected controller type: {controller_type}")
     return controller_type
 
 
-def _find_credential_sets() -> tuple[list[str], dict[str, CredentialSetStatus]]:
+def _find_credential_sets() -> tuple[
+    list[str], dict[str, CredentialSetStatus], dict[str, CredentialSet]
+]:
     """Find complete and partial credential sets in environment.
 
     Examines environment variables to identify which controller types have
@@ -285,10 +303,11 @@ def _find_credential_sets() -> tuple[list[str], dict[str, CredentialSetStatus]]:
         A tuple containing:
             - List of controller types with complete credentials
             - Dictionary mapping controller types to CredentialSetStatus
+            - Dictionary mapping controller types to the winning CredentialSet
 
     Example:
         >>> os.environ.update({"ACI_URL": "https://apic.local", "ACI_USERNAME": "admin"})
-        >>> complete, partial = _find_credential_sets()
+        >>> complete, partial, matched = _find_credential_sets()
         >>> print(complete)
         []
         >>> print(partial)
@@ -296,6 +315,7 @@ def _find_credential_sets() -> tuple[list[str], dict[str, CredentialSetStatus]]:
     """
     complete_sets: list[str] = []
     partial_sets: dict[str, CredentialSetStatus] = {}
+    matched_creds: dict[str, CredentialSet] = {}
 
     for controller_type, config in CONTROLLER_REGISTRY.items():
         best_present: list[str] = []
@@ -335,6 +355,7 @@ def _find_credential_sets() -> tuple[list[str], dict[str, CredentialSetStatus]]:
             if present_vars and not missing_vars:
                 # This credential set is fully satisfied — first wins
                 complete_sets.append(controller_type)
+                matched_creds[controller_type] = cred_set
                 logger.debug(
                     f"  {controller_type}: Complete via {cred_set.label}"
                 )
@@ -352,7 +373,7 @@ def _find_credential_sets() -> tuple[list[str], dict[str, CredentialSetStatus]]:
                 "missing": best_missing,
             }
 
-    return complete_sets, partial_sets
+    return complete_sets, partial_sets, matched_creds
 
 
 def _format_multiple_credentials_error(controllers: list[str]) -> str:
@@ -565,3 +586,30 @@ def get_controller_url(controller_type: str) -> str:
 
     # No URL found - raise KeyError with the primary var name
     raise KeyError(config.url_env_var)
+
+
+def get_matched_credential_set(controller_type: str) -> CredentialSet | None:
+    """Get the credential set that was matched during controller detection.
+
+    Returns the CredentialSet that satisfied detection for the given controller
+    type. This is populated by detect_controller_type() and is intended for use
+    by auth adapters in nac-test-pyats-common to determine which authentication
+    mechanism to use (via the auth_method attribute).
+
+    Args:
+        controller_type: The controller type key (e.g., "SDWAN", "ACI").
+
+    Returns:
+        The matched CredentialSet, or None if detect_controller_type() has not
+        been called or the controller type was not detected.
+
+    Example:
+        >>> detect_controller_type()  # populates the cache
+        'SDWAN'
+        >>> cred = get_matched_credential_set("SDWAN")
+        >>> cred.auth_method
+        'token'
+        >>> cred.label
+        'API Token (20.18+)'
+    """
+    return _matched_credential_sets.get(controller_type)

--- a/nac_test/utils/controller.py
+++ b/nac_test/utils/controller.py
@@ -87,7 +87,7 @@ class ControllerConfig:
 
 
 # Single source of truth for all controller configurations
-# Replaces both CREDENTIAL_PATTERNS and the registry from controller_auth.py
+# Replaces the registry from controller_auth.py
 CONTROLLER_REGISTRY: dict[str, ControllerConfig] = {
     "ACI": ControllerConfig(
         display_name="APIC",
@@ -183,13 +183,6 @@ CONTROLLER_REGISTRY: dict[str, ControllerConfig] = {
         defaults_prefix="defaults.iosxe",
         alt_url_env_vars=["IOSXE_HOST"],  # Alternative env var for URL
     ),
-}
-
-# Backward compatibility - remove in future version
-# Uses the first credential set's env_vars as the "primary" pattern
-CREDENTIAL_PATTERNS: dict[str, list[str]] = {
-    controller_type: config.credential_sets[0].env_vars
-    for controller_type, config in CONTROLLER_REGISTRY.items()
 }
 
 # Module-level cache for the credential set that was matched during detection.
@@ -403,9 +396,7 @@ def _format_multiple_credentials_error(controllers: list[str]) -> str:
 
     # Collect all env vars per controller (union of all credential sets)
     def _all_env_vars(controller: str) -> list[str]:
-        config = CONTROLLER_REGISTRY.get(controller)
-        if not config:
-            return CREDENTIAL_PATTERNS.get(controller, [])
+        config = CONTROLLER_REGISTRY[controller]
         seen: set[str] = set()
         result: list[str] = []
         for cs in config.credential_sets:

--- a/nac_test/utils/controller.py
+++ b/nac_test/utils/controller.py
@@ -356,9 +356,7 @@ def _find_credential_sets() -> tuple[
                 # This credential set is fully satisfied — first wins
                 complete_sets.append(controller_type)
                 matched_creds[controller_type] = cred_set
-                logger.debug(
-                    f"  {controller_type}: Complete via {cred_set.label}"
-                )
+                logger.debug(f"  {controller_type}: Complete via {cred_set.label}")
                 found_complete = True
                 break
 

--- a/nac_test/utils/controller.py
+++ b/nac_test/utils/controller.py
@@ -207,46 +207,43 @@ def detect_controller_type() -> ControllerTypeKey:
     logger.debug("Starting controller type detection")
     logger.debug(f"Checking for credentials: {list(CONTROLLER_REGISTRY.keys())}")
 
-    complete_sets, partial_controllers, matched_creds = _find_credential_sets()
+    complete, partial = _find_credential_sets()
 
-    logger.debug(f"Complete credential sets found: {complete_sets}")
-    logger.debug(f"Partial credential sets found: {partial_controllers}")
+    logger.debug(f"Complete credential sets found: {list(complete.keys())}")
+    logger.debug(f"Partial credential sets found: {partial}")
 
     # Check for multiple complete credential sets
-    if len(complete_sets) > 1:
-        error_message = _format_multiple_credentials_error(complete_sets)
-        logger.error(f"Multiple controller credentials detected: {complete_sets}")
+    if len(complete) > 1:
+        error_message = _format_multiple_credentials_error(list(complete.keys()))
+        logger.error(f"Multiple controller credentials detected: {list(complete.keys())}")
         raise ValueError(error_message)
 
     # Check for no credentials at all
-    if not complete_sets and not partial_controllers:
+    if not complete and not partial:
         error_message = _format_no_credentials_error()
         logger.error("No controller credentials found in environment")
         raise ValueError(error_message)
 
     # Check for incomplete credentials
-    if not complete_sets and partial_controllers:
-        error_message = _format_incomplete_credentials_error(partial_controllers)
-        logger.error(f"Incomplete credentials: {partial_controllers}")
+    if not complete and partial:
+        error_message = _format_incomplete_credentials_error(partial)
+        logger.error(f"Incomplete credentials: {partial}")
         raise ValueError(error_message)
 
     # Exactly one complete set found - success
-    # complete_sets come from CONTROLLER_REGISTRY keys, which are always valid
-    # ControllerTypeKey values, but mypy can't infer this from dict iteration.
-    controller_type = cast(ControllerTypeKey, complete_sets[0])
-    # Store the winning credential set for retrieval by auth adapters
-    if controller_type in matched_creds:
-        _matched_credential_sets[controller_type] = matched_creds[controller_type]
-        logger.info(
-            f"Detected controller type: {controller_type} "
-            f"(auth_method={matched_creds[controller_type].auth_method})"
-        )
-    else:
-        logger.info(f"Detected controller type: {controller_type}")
+    controller_type = next(iter(complete))
+    _matched_credential_sets[controller_type] = complete[controller_type]
+    logger.info(
+        f"Detected controller type: {controller_type} "
+        f"(auth_method={complete[controller_type].auth_method})"
+    )
     return controller_type
 
 
-def _find_credential_sets() -> tuple[list[str], list[str], dict[str, CredentialSet]]:
+def _find_credential_sets() -> tuple[
+    dict[ControllerTypeKey, CredentialSet],
+    list[ControllerTypeKey],
+]:
     """Find complete and partial credential sets in environment.
 
     For each controller, iterates through its credential_sets in order. The first
@@ -256,17 +253,16 @@ def _find_credential_sets() -> tuple[list[str], list[str], dict[str, CredentialS
 
     Returns:
         A tuple containing:
-            - List of controller types with complete credentials
+            - Dictionary mapping complete controller types to the winning CredentialSet
             - List of controller types with partial credentials
-            - Dictionary mapping controller types to the winning CredentialSet
     """
-    complete_sets: list[str] = []
-    partial_controllers: list[str] = []
-    matched_creds: dict[str, CredentialSet] = {}
+    complete: dict[ControllerTypeKey, CredentialSet] = {}
+    partial: list[ControllerTypeKey] = []
 
     for controller_type, config in CONTROLLER_REGISTRY.items():
         found_complete = False
         has_any_var = False
+        ct_key = cast(ControllerTypeKey, controller_type)
 
         for cred_set in config.credential_sets:
             all_present = True
@@ -280,16 +276,15 @@ def _find_credential_sets() -> tuple[list[str], list[str], dict[str, CredentialS
                     all_present = False
 
             if all_present:
-                complete_sets.append(controller_type)
-                matched_creds[controller_type] = cred_set
+                complete[ct_key] = cred_set
                 logger.debug(f"  {controller_type}: Complete via {cred_set.label}")
                 found_complete = True
                 break
 
         if not found_complete and has_any_var:
-            partial_controllers.append(controller_type)
+            partial.append(ct_key)
 
-    return complete_sets, partial_controllers, matched_creds
+    return complete, partial
 
 
 def _format_incomplete_credentials_error(partial_controllers: list[str]) -> str:

--- a/nac_test/utils/environment.py
+++ b/nac_test/utils/environment.py
@@ -124,8 +124,8 @@ class EnvironmentValidator:
 
         Iterates through the controller's credential_sets. If any set is fully
         satisfied (all env vars present and non-empty), validation passes.
-        Otherwise falls back to checking the first credential set's vars and
-        reports missing ones.
+        Otherwise reports all accepted credential sets so the user knows
+        exactly which variables are needed.
 
         Args:
             controller_type: Type of controller (ACI, CC, SDWAN, etc.)
@@ -133,7 +133,11 @@ class EnvironmentValidator:
         Raises:
             SystemExit: If no credential set is fully satisfied
         """
-        from nac_test.utils.controller import CONTROLLER_REGISTRY, _is_env_var_set
+        from nac_test.utils.controller import (
+            CONTROLLER_REGISTRY,
+            _format_incomplete_credentials_error,
+            _is_env_var_set,
+        )
 
         config = CONTROLLER_REGISTRY.get(controller_type)
         if config:
@@ -142,9 +146,9 @@ class EnvironmentValidator:
                 if all(_is_env_var_set(v) for v in cred_set.env_vars):
                     return  # Credentials satisfied
 
-            # No set fully satisfied — report missing vars from first set
-            # (the "default" credential method)
-            required_vars = config.credential_sets[0].env_vars
+            # No set fully satisfied — report all accepted credential sets
+            error_msg = _format_incomplete_credentials_error([controller_type])
+            sys.exit(error_msg)
         else:
             # Fallback for unknown controller types
             required_vars = [
@@ -153,10 +157,12 @@ class EnvironmentValidator:
                 f"{controller_type}_PASSWORD",
             ]
 
-        # Use terminal's controller-specific formatter
-        def controller_formatter(missing: list[str]) -> str:
-            return terminal.format_env_var_error(missing, controller_type)
+            # Use terminal's controller-specific formatter
+            def controller_formatter(missing: list[str]) -> str:
+                return terminal.format_env_var_error(missing, controller_type)
 
-        EnvironmentValidator.check_required_vars(
-            required_vars, exit_on_missing=True, custom_formatter=controller_formatter
-        )
+            EnvironmentValidator.check_required_vars(
+                required_vars,
+                exit_on_missing=True,
+                custom_formatter=controller_formatter,
+            )

--- a/nac_test/utils/environment.py
+++ b/nac_test/utils/environment.py
@@ -133,13 +133,13 @@ class EnvironmentValidator:
         Raises:
             SystemExit: If no credential set is fully satisfied
         """
-        from nac_test.utils.controller import CONTROLLER_REGISTRY
+        from nac_test.utils.controller import CONTROLLER_REGISTRY, _is_env_var_set
 
         config = CONTROLLER_REGISTRY.get(controller_type)
         if config:
             # Check each credential set — first fully satisfied wins
             for cred_set in config.credential_sets:
-                if all(os.environ.get(v, "").strip() for v in cred_set.env_vars):
+                if all(_is_env_var_set(v) for v in cred_set.env_vars):
                     return  # Credentials satisfied
 
             # No set fully satisfied — report missing vars from first set

--- a/nac_test/utils/environment.py
+++ b/nac_test/utils/environment.py
@@ -122,19 +122,36 @@ class EnvironmentValidator:
     def validate_controller_env(controller_type: str = "ACI") -> None:
         """Validate controller-specific environment variables.
 
-        This is a convenience method for validating controller credentials.
+        Iterates through the controller's credential_sets. If any set is fully
+        satisfied (all env vars present and non-empty), validation passes.
+        Otherwise falls back to checking the first credential set's vars and
+        reports missing ones.
 
         Args:
-            controller_type: Type of controller (ACI, CC, etc.)
+            controller_type: Type of controller (ACI, CC, SDWAN, etc.)
 
         Raises:
-            SystemExit: If required variables are missing
+            SystemExit: If no credential set is fully satisfied
         """
-        required_vars = [
-            f"{controller_type}_URL",
-            f"{controller_type}_USERNAME",
-            f"{controller_type}_PASSWORD",
-        ]
+        from nac_test.utils.controller import CONTROLLER_REGISTRY
+
+        config = CONTROLLER_REGISTRY.get(controller_type)
+        if config:
+            # Check each credential set — first fully satisfied wins
+            for cred_set in config.credential_sets:
+                if all(os.environ.get(v, "").strip() for v in cred_set.env_vars):
+                    return  # Credentials satisfied
+
+            # No set fully satisfied — report missing vars from first set
+            # (the "default" credential method)
+            required_vars = config.credential_sets[0].env_vars
+        else:
+            # Fallback for unknown controller types
+            required_vars = [
+                f"{controller_type}_URL",
+                f"{controller_type}_USERNAME",
+                f"{controller_type}_PASSWORD",
+            ]
 
         # Use terminal's controller-specific formatter
         def controller_formatter(missing: list[str]) -> str:

--- a/tests/pyats_core/conftest.py
+++ b/tests/pyats_core/conftest.py
@@ -26,7 +26,7 @@ class PyATSTestDirs(NamedTuple):
     merged_file: Path
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=True)
 def clean_controller_env(monkeypatch: MonkeyPatch) -> None:
     """Clear all controller-related environment variables.
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -68,7 +68,7 @@ def assert_connection_has_optimizations(connection: dict[str, Any]) -> None:
     )
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=True)
 def clean_controller_env(monkeypatch: MonkeyPatch) -> None:
     """Clear all controller-related environment variables.
 

--- a/tests/unit/pyats_core/common/test_base_test_iosxe_credentials.py
+++ b/tests/unit/pyats_core/common/test_base_test_iosxe_credentials.py
@@ -1,15 +1,12 @@
 # SPDX-License-Identifier: MPL-2.0
 # Copyright (c) 2025 Daniel Schmidt
 
-"""Tests for NACTestBase setup() with IOSXE controller (optional credentials).
+"""Tests for NACTestBase setup() with IOSXE controller credentials.
 
-IOSXE is unique among supported controllers - it's the only one that doesn't
-require USERNAME/PASSWORD environment variables. This is because D2D tests
-use device-specific credentials from the device inventory, not controller
-credentials.
-
-This test verifies that setup() handles optional credentials correctly for
-IOSXE while still requiring them for other controller types.
+IOSXE supports two URL forms (IOSXE_URL and IOSXE_HOST) via separate
+credential sets, but always requires USERNAME and PASSWORD alongside
+the URL/HOST variable. This test verifies that setup() handles IOSXE
+credentials correctly.
 """
 
 import json
@@ -40,20 +37,19 @@ def temp_data_model_file(
 class TestIOSXEOptionalCredentials:
     """Test that IOSXE controller type handles optional USERNAME/PASSWORD."""
 
-    def test_iosxe_setup_works_without_username_password(
+    def test_iosxe_setup_fails_without_username_password(
         self,
         nac_test_base_class: Any,
         temp_data_model_file: Path,
         iosxe_controller_env: None,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """setup() should succeed for IOSXE with only URL (no USERNAME/PASSWORD).
+        """setup() should fail for IOSXE without USERNAME/PASSWORD.
 
-        IOSXE is unique - it only requires IOSXE_URL per CONTROLLER_REGISTRY.
-        D2D tests use device-specific credentials from inventory, not controller
-        credentials.
+        IOSXE now requires IOSXE_USERNAME and IOSXE_PASSWORD in addition to
+        IOSXE_URL (or IOSXE_HOST). Detection should report incomplete credentials.
         """
-        # Remove USERNAME and PASSWORD to simulate real IOSXE environment
+        # Remove USERNAME and PASSWORD to simulate incomplete IOSXE environment
         monkeypatch.delenv("IOSXE_USERNAME", raising=False)
         monkeypatch.delenv("IOSXE_PASSWORD", raising=False)
 
@@ -62,16 +58,15 @@ class TestIOSXEOptionalCredentials:
         assert "IOSXE_USERNAME" not in os.environ
         assert "IOSXE_PASSWORD" not in os.environ
 
-        # Create instance
         instance = nac_test_base_class.__new__(nac_test_base_class)
 
-        # setup() should succeed even without USERNAME/PASSWORD
-        instance.setup()
+        # setup() should fail with incomplete credentials
+        with pytest.raises(ValueError) as exc_info:
+            instance.setup()
 
-        assert instance.controller_type == "IOSXE"
-        assert instance.controller_url == "https://test.example.com"
-        assert instance.username is None
-        assert instance.password is None
+        error_msg = str(exc_info.value)
+        assert "Incomplete controller credentials detected" in error_msg
+        assert "IOSXE" in error_msg
 
     def test_iosxe_setup_works_with_username_password(
         self,

--- a/tests/unit/pyats_core/common/test_base_test_iosxe_credentials.py
+++ b/tests/unit/pyats_core/common/test_base_test_iosxe_credentials.py
@@ -141,4 +141,4 @@ class TestIOSXEOptionalCredentials:
             instance.setup()
 
         assert "Incomplete controller credentials" in str(exc_info.value)
-        assert "ACI: missing ACI_USERNAME" in str(exc_info.value)
+        assert "ACI: incomplete credentials" in str(exc_info.value)

--- a/tests/utils/test_controller.py
+++ b/tests/utils/test_controller.py
@@ -361,6 +361,29 @@ class TestEdgeCases:
         result = detect_controller_type()
         assert result == "SDWAN"
 
+    def test_iosxe_partial_and_sdwan_partial_are_both_reported(self) -> None:
+        """Regression test: IOSXE_URL + IOSXE_PASSWORD (no IOSXE_USERNAME) combined
+        with SDWAN_URL must NOT detect IOSXE — both controllers should be reported
+        as partial, not complete.
+
+        Before the fix that added IOSXE_USERNAME/IOSXE_PASSWORD to the IOSXE
+        credential sets, setting only IOSXE_URL was enough to satisfy detection,
+        so this combination incorrectly returned 'IOSXE' instead of raising.
+        """
+        os.environ["IOSXE_URL"] = "https://iosxe.example.com"
+        os.environ["IOSXE_PASSWORD"] = "cisco123"
+        # IOSXE_USERNAME deliberately omitted — credential set must not be satisfied
+        os.environ["SDWAN_URL"] = "https://vmanage.example.com"
+        # No SDWAN credentials beyond URL
+
+        with pytest.raises(ValueError) as exc_info:
+            detect_controller_type()
+
+        error_msg = str(exc_info.value)
+        assert "Incomplete controller credentials detected" in error_msg
+        assert "IOSXE: incomplete credentials" in error_msg
+        assert "SDWAN: incomplete credentials" in error_msg
+
 
 class TestIOSXEAlternativeURLEnvVar:
     """Test IOSXE controller detection with alternative URL environment variables.

--- a/tests/utils/test_controller.py
+++ b/tests/utils/test_controller.py
@@ -175,12 +175,12 @@ class TestHelperFunctions:
         os.environ["CC_USERNAME"] = "admin"
         os.environ["CC_PASSWORD"] = "password"
 
-        complete, partial, matched = _find_credential_sets()
+        complete, partial = _find_credential_sets()
 
-        assert complete == ["CC"]
+        assert list(complete.keys()) == ["CC"]
         assert partial == []
-        assert "CC" in matched
-        assert matched["CC"].auth_method == "session"
+        assert "CC" in complete
+        assert complete["CC"].auth_method == "session"
 
     def test_find_credential_sets_partial(self) -> None:
         """Test finding partial credential sets."""
@@ -189,11 +189,10 @@ class TestHelperFunctions:
         os.environ["FMC_USERNAME"] = "admin"
         # No FMC_PASSWORD
 
-        complete, partial, matched = _find_credential_sets()
+        complete, partial = _find_credential_sets()
 
-        assert complete == []
+        assert complete == {}
         assert "FMC" in partial
-        assert matched == {}
 
     def test_find_credential_sets_multiple_partial(self) -> None:
         """Test finding multiple partial credential sets."""
@@ -205,13 +204,12 @@ class TestHelperFunctions:
         os.environ["MERAKI_USERNAME"] = "meraki_user"
         # Missing MERAKI_URL and MERAKI_PASSWORD
 
-        complete, partial, matched = _find_credential_sets()
+        complete, partial = _find_credential_sets()
 
-        assert complete == []
+        assert complete == {}
         assert len(partial) == 2
         assert "ISE" in partial
         assert "MERAKI" in partial
-        assert matched == {}
 
     def test_format_multiple_credentials_error(self) -> None:
         """Test formatting error message for multiple controllers."""

--- a/tests/utils/test_controller.py
+++ b/tests/utils/test_controller.py
@@ -22,29 +22,28 @@ from nac_test.utils.controller import (
 )
 
 
+@pytest.fixture(autouse=True)
+def clean_environment() -> Generator[None, None, None]:
+    """Clean controller env vars and matched-credential cache for every test."""
+    original_env = os.environ.copy()
+
+    for config in CONTROLLER_REGISTRY.values():
+        for cred_set in config.credential_sets:
+            for var in cred_set.env_vars:
+                os.environ.pop(var, None)
+
+    os.environ.pop("CONTROLLER_TYPE", None)
+    _matched_credential_sets.clear()
+
+    yield
+
+    _matched_credential_sets.clear()
+    os.environ.clear()
+    os.environ.update(original_env)
+
+
 class TestControllerDetection:
     """Test controller type detection functionality."""
-
-    @pytest.fixture(autouse=True)
-    def clean_environment(self) -> Generator[None, None, None]:
-        """Clean environment variables before and after each test."""
-        # Store original environment
-        original_env = os.environ.copy()
-
-        # Remove all controller-related variables (all credential sets)
-        for config in CONTROLLER_REGISTRY.values():
-            for cred_set in config.credential_sets:
-                for var in cred_set.env_vars:
-                    os.environ.pop(var, None)
-
-        # Also remove legacy CONTROLLER_TYPE if present
-        os.environ.pop("CONTROLLER_TYPE", None)
-
-        yield
-
-        # Restore original environment
-        os.environ.clear()
-        os.environ.update(original_env)
 
     @pytest.mark.parametrize(
         "controller_type,env_vars",
@@ -169,21 +168,6 @@ class TestControllerDetection:
 class TestHelperFunctions:
     """Test helper functions for credential detection."""
 
-    @pytest.fixture(autouse=True)
-    def clean_environment(self) -> Generator[None, None, None]:
-        """Clean environment variables before and after each test."""
-        original_env = os.environ.copy()
-
-        for config in CONTROLLER_REGISTRY.values():
-            for cred_set in config.credential_sets:
-                for var in cred_set.env_vars:
-                    os.environ.pop(var, None)
-
-        yield
-
-        os.environ.clear()
-        os.environ.update(original_env)
-
     def test_find_credential_sets_complete(self) -> None:
         """Test finding complete credential sets."""
         # Set complete credentials for CC
@@ -264,21 +248,6 @@ class TestHelperFunctions:
 
 class TestEdgeCases:
     """Test edge cases and special scenarios."""
-
-    @pytest.fixture(autouse=True)
-    def clean_environment(self) -> Generator[None, None, None]:
-        """Clean environment variables before and after each test."""
-        original_env = os.environ.copy()
-
-        for config in CONTROLLER_REGISTRY.values():
-            for cred_set in config.credential_sets:
-                for var in cred_set.env_vars:
-                    os.environ.pop(var, None)
-
-        yield
-
-        os.environ.clear()
-        os.environ.update(original_env)
 
     def test_case_sensitivity(self) -> None:
         """Test that environment variable names are case-sensitive."""
@@ -401,22 +370,6 @@ class TestIOSXEAlternativeURLEnvVar:
     via separate credential sets. The first matching credential set wins.
     """
 
-    @pytest.fixture(autouse=True)
-    def clean_environment(self) -> Generator[None, None, None]:
-        """Clean environment variables before and after each test."""
-        original_env = os.environ.copy()
-
-        # Remove all controller-related variables
-        for config in CONTROLLER_REGISTRY.values():
-            for cred_set in config.credential_sets:
-                for var in cred_set.env_vars:
-                    os.environ.pop(var, None)
-
-        yield
-
-        os.environ.clear()
-        os.environ.update(original_env)
-
     def test_detect_iosxe_with_url(self) -> None:
         """Test IOSXE detection with standard IOSXE_URL env var."""
         os.environ["IOSXE_URL"] = "https://iosxe.example.com"
@@ -493,21 +446,6 @@ class TestIOSXEAlternativeURLEnvVar:
 class TestGetControllerUrl:
     """Tests for get_controller_url function."""
 
-    @pytest.fixture(autouse=True)
-    def clean_environment(self) -> Generator[None, None, None]:
-        """Clean environment variables before and after each test."""
-        original_env = os.environ.copy()
-
-        for config in CONTROLLER_REGISTRY.values():
-            for cred_set in config.credential_sets:
-                for var in cred_set.env_vars:
-                    os.environ.pop(var, None)
-
-        yield
-
-        os.environ.clear()
-        os.environ.update(original_env)
-
     @pytest.mark.parametrize(
         "controller_type,url_env_var",
         [
@@ -552,25 +490,6 @@ class TestSDWANCredentialSets:
     1. API Token (20.18+): SDWAN_URL + SDWAN_API_TOKEN  (first — wins when both present)
     2. Username/Password: SDWAN_URL + SDWAN_USERNAME + SDWAN_PASSWORD
     """
-
-    @pytest.fixture(autouse=True)
-    def clean_environment(self) -> Generator[None, None, None]:
-        """Clean environment variables before and after each test."""
-        original_env = os.environ.copy()
-
-        for config in CONTROLLER_REGISTRY.values():
-            for cred_set in config.credential_sets:
-                for var in cred_set.env_vars:
-                    os.environ.pop(var, None)
-
-        # Clear matched credential set cache
-        _matched_credential_sets.clear()
-
-        yield
-
-        _matched_credential_sets.clear()
-        os.environ.clear()
-        os.environ.update(original_env)
 
     def test_detect_sdwan_with_api_token(self) -> None:
         """Test SDWAN detection with API token credentials."""

--- a/tests/utils/test_controller.py
+++ b/tests/utils/test_controller.py
@@ -372,6 +372,8 @@ class TestIOSXEAlternativeURLEnvVar:
     def test_detect_iosxe_with_url(self) -> None:
         """Test IOSXE detection with standard IOSXE_URL env var."""
         os.environ["IOSXE_URL"] = "https://iosxe.example.com"
+        os.environ["IOSXE_USERNAME"] = "admin"
+        os.environ["IOSXE_PASSWORD"] = "password"
 
         result = detect_controller_type()
         assert result == "IOSXE"
@@ -379,6 +381,8 @@ class TestIOSXEAlternativeURLEnvVar:
     def test_detect_iosxe_with_host(self) -> None:
         """Test IOSXE detection with alternative IOSXE_HOST env var."""
         os.environ["IOSXE_HOST"] = "192.168.1.1"
+        os.environ["IOSXE_USERNAME"] = "admin"
+        os.environ["IOSXE_PASSWORD"] = "password"
 
         result = detect_controller_type()
         assert result == "IOSXE"
@@ -387,6 +391,8 @@ class TestIOSXEAlternativeURLEnvVar:
         """When both IOSXE_URL and IOSXE_HOST are set, URL takes precedence."""
         os.environ["IOSXE_URL"] = "https://iosxe-url.example.com"
         os.environ["IOSXE_HOST"] = "192.168.1.1"
+        os.environ["IOSXE_USERNAME"] = "admin"
+        os.environ["IOSXE_PASSWORD"] = "password"
 
         result = detect_controller_type()
         assert result == "IOSXE"

--- a/tests/utils/test_controller.py
+++ b/tests/utils/test_controller.py
@@ -397,8 +397,8 @@ class TestEdgeCases:
 class TestIOSXEAlternativeURLEnvVar:
     """Test IOSXE controller detection with alternative URL environment variables.
 
-    IOSXE supports both IOSXE_URL and IOSXE_HOST as the URL environment variable.
-    This was introduced to support alternative connection methods in XE-as-code.
+    IOSXE supports both IOSXE_URL and IOSXE_HOST as the URL environment variable
+    via separate credential sets. The first matching credential set wins.
     """
 
     @pytest.fixture(autouse=True)
@@ -411,9 +411,6 @@ class TestIOSXEAlternativeURLEnvVar:
             for cred_set in config.credential_sets:
                 for var in cred_set.env_vars:
                     os.environ.pop(var, None)
-
-        # Also remove IOSXE_HOST alternative
-        os.environ.pop("IOSXE_HOST", None)
 
         yield
 
@@ -505,8 +502,6 @@ class TestGetControllerUrl:
             for cred_set in config.credential_sets:
                 for var in cred_set.env_vars:
                     os.environ.pop(var, None)
-
-        os.environ.pop("IOSXE_HOST", None)
 
         yield
 

--- a/tests/utils/test_controller.py
+++ b/tests/utils/test_controller.py
@@ -121,7 +121,7 @@ class TestControllerDetection:
 
         error_msg = str(exc_info.value)
         assert "Incomplete controller credentials detected" in error_msg
-        assert "ACI: missing ACI_PASSWORD" in error_msg
+        assert "ACI: incomplete credentials" in error_msg
 
     def test_empty_string_handling(self) -> None:
         """Test that empty string values are treated as missing."""
@@ -135,7 +135,7 @@ class TestControllerDetection:
 
         error_msg = str(exc_info.value)
         assert "Incomplete controller credentials detected" in error_msg
-        assert "ACI: missing ACI_PASSWORD" in error_msg
+        assert "ACI: incomplete credentials" in error_msg
 
     def test_whitespace_handling(self) -> None:
         """Test that whitespace-only values are treated as missing."""
@@ -149,7 +149,7 @@ class TestControllerDetection:
 
         error_msg = str(exc_info.value)
         assert "Incomplete controller credentials detected" in error_msg
-        assert "SDWAN: missing SDWAN_PASSWORD" in error_msg
+        assert "SDWAN: incomplete credentials" in error_msg
 
     def test_d2d_scenario_with_dummy_credentials(self) -> None:
         """Test D2D scenario where controller credentials are still required."""
@@ -194,7 +194,7 @@ class TestHelperFunctions:
         complete, partial, matched = _find_credential_sets()
 
         assert complete == ["CC"]
-        assert partial == {}
+        assert partial == []
         assert "CC" in matched
         assert matched["CC"].auth_method == "session"
 
@@ -209,8 +209,6 @@ class TestHelperFunctions:
 
         assert complete == []
         assert "FMC" in partial
-        assert partial["FMC"]["present"] == ["FMC_URL", "FMC_USERNAME"]
-        assert partial["FMC"]["missing"] == ["FMC_PASSWORD"]
         assert matched == {}
 
     def test_find_credential_sets_multiple_partial(self) -> None:
@@ -229,8 +227,6 @@ class TestHelperFunctions:
         assert len(partial) == 2
         assert "ISE" in partial
         assert "MERAKI" in partial
-        assert partial["ISE"]["missing"] == ["ISE_USERNAME", "ISE_PASSWORD"]
-        assert partial["MERAKI"]["missing"] == ["MERAKI_URL", "MERAKI_PASSWORD"]
         assert matched == {}
 
     def test_format_multiple_credentials_error(self) -> None:

--- a/tests/utils/test_controller.py
+++ b/tests/utils/test_controller.py
@@ -596,7 +596,7 @@ class TestSDWANCredentialSets:
 
     def test_credential_set_auth_method_default(self) -> None:
         """CredentialSet.auth_method defaults to 'session'."""
-        cs = CredentialSet(env_vars=["X_URL", "X_USER", "X_PASS"], label="test")
+        cs = CredentialSet(env_vars=("X_URL", "X_USER", "X_PASS"), label="test")
         assert cs.auth_method == "session"
 
     def test_aci_matched_credential_set(self) -> None:

--- a/tests/utils/test_controller.py
+++ b/tests/utils/test_controller.py
@@ -87,7 +87,9 @@ class TestControllerDetection:
         error_msg = str(exc_info.value)
         assert "Multiple controller credentials detected: ACI, SDWAN" in error_msg
         # SDWAN has multiple credential sets — unset should include all env vars
-        assert "unset SDWAN_URL SDWAN_API_TOKEN SDWAN_USERNAME SDWAN_PASSWORD" in error_msg
+        assert (
+            "unset SDWAN_URL SDWAN_API_TOKEN SDWAN_USERNAME SDWAN_PASSWORD" in error_msg
+        )
         assert "unset ACI_URL ACI_USERNAME ACI_PASSWORD" in error_msg
 
     def test_no_credentials_error(self) -> None:
@@ -238,7 +240,9 @@ class TestHelperFunctions:
         assert "Multiple controller credentials detected: ACI, SDWAN, CC" in error_msg
         assert "To use ACI only:" in error_msg
         # SDWAN has two credential sets, so all env vars from both sets appear
-        assert "unset SDWAN_URL SDWAN_API_TOKEN SDWAN_USERNAME SDWAN_PASSWORD" in error_msg
+        assert (
+            "unset SDWAN_URL SDWAN_API_TOKEN SDWAN_USERNAME SDWAN_PASSWORD" in error_msg
+        )
         assert "CC_URL CC_USERNAME CC_PASSWORD" in error_msg
         assert "To use SDWAN only:" in error_msg
         assert (

--- a/tests/utils/test_controller.py
+++ b/tests/utils/test_controller.py
@@ -11,11 +11,14 @@ import pytest
 
 from nac_test.utils.controller import (
     CONTROLLER_REGISTRY,
+    CredentialSet,
     _find_credential_sets,
     _format_multiple_credentials_error,
     _format_no_credentials_error,
+    _matched_credential_sets,
     detect_controller_type,
     get_controller_url,
+    get_matched_credential_set,
 )
 
 
@@ -186,10 +189,12 @@ class TestHelperFunctions:
         os.environ["CC_USERNAME"] = "admin"
         os.environ["CC_PASSWORD"] = "password"
 
-        complete, partial = _find_credential_sets()
+        complete, partial, matched = _find_credential_sets()
 
         assert complete == ["CC"]
         assert partial == {}
+        assert "CC" in matched
+        assert matched["CC"].auth_method == "session"
 
     def test_find_credential_sets_partial(self) -> None:
         """Test finding partial credential sets."""
@@ -198,12 +203,13 @@ class TestHelperFunctions:
         os.environ["FMC_USERNAME"] = "admin"
         # No FMC_PASSWORD
 
-        complete, partial = _find_credential_sets()
+        complete, partial, matched = _find_credential_sets()
 
         assert complete == []
         assert "FMC" in partial
         assert partial["FMC"]["present"] == ["FMC_URL", "FMC_USERNAME"]
         assert partial["FMC"]["missing"] == ["FMC_PASSWORD"]
+        assert matched == {}
 
     def test_find_credential_sets_multiple_partial(self) -> None:
         """Test finding multiple partial credential sets."""
@@ -215,7 +221,7 @@ class TestHelperFunctions:
         os.environ["MERAKI_USERNAME"] = "meraki_user"
         # Missing MERAKI_URL and MERAKI_PASSWORD
 
-        complete, partial = _find_credential_sets()
+        complete, partial, matched = _find_credential_sets()
 
         assert complete == []
         assert len(partial) == 2
@@ -223,6 +229,7 @@ class TestHelperFunctions:
         assert "MERAKI" in partial
         assert partial["ISE"]["missing"] == ["ISE_USERNAME", "ISE_PASSWORD"]
         assert partial["MERAKI"]["missing"] == ["MERAKI_URL", "MERAKI_PASSWORD"]
+        assert matched == {}
 
     def test_format_multiple_credentials_error(self) -> None:
         """Test formatting error message for multiple controllers."""
@@ -561,8 +568,12 @@ class TestSDWANCredentialSets:
                 for var in cred_set.env_vars:
                     os.environ.pop(var, None)
 
+        # Clear matched credential set cache
+        _matched_credential_sets.clear()
+
         yield
 
+        _matched_credential_sets.clear()
         os.environ.clear()
         os.environ.update(original_env)
 
@@ -574,6 +585,12 @@ class TestSDWANCredentialSets:
         result = detect_controller_type()
         assert result == "SDWAN"
 
+        # Token set should be matched with auth_method="token"
+        cred = get_matched_credential_set("SDWAN")
+        assert cred is not None
+        assert cred.auth_method == "token"
+        assert cred.label == "API Token (20.18+)"
+
     def test_detect_sdwan_with_username_password(self) -> None:
         """Test SDWAN detection with traditional username/password."""
         os.environ["SDWAN_URL"] = "https://vmanage.example.com"
@@ -582,6 +599,12 @@ class TestSDWANCredentialSets:
 
         result = detect_controller_type()
         assert result == "SDWAN"
+
+        # Password set should be matched with auth_method="session"
+        cred = get_matched_credential_set("SDWAN")
+        assert cred is not None
+        assert cred.auth_method == "session"
+        assert cred.label == "Username/Password"
 
     def test_api_token_takes_priority(self) -> None:
         """When both credential sets are satisfied, token set wins (listed first)."""
@@ -594,6 +617,11 @@ class TestSDWANCredentialSets:
         result = detect_controller_type()
         assert result == "SDWAN"
 
+        # Token set wins because it's listed first
+        cred = get_matched_credential_set("SDWAN")
+        assert cred is not None
+        assert cred.auth_method == "token"
+
     def test_partial_token_set_falls_back_to_password(self) -> None:
         """When SDWAN_API_TOKEN is missing but username/password present, detect SDWAN."""
         os.environ["SDWAN_URL"] = "https://vmanage.example.com"
@@ -604,6 +632,11 @@ class TestSDWANCredentialSets:
         result = detect_controller_type()
         assert result == "SDWAN"
 
+        # Password set matched because token set was incomplete
+        cred = get_matched_credential_set("SDWAN")
+        assert cred is not None
+        assert cred.auth_method == "session"
+
     def test_empty_api_token_falls_back_to_password(self) -> None:
         """Empty SDWAN_API_TOKEN should not satisfy the token credential set."""
         os.environ["SDWAN_URL"] = "https://vmanage.example.com"
@@ -613,6 +646,11 @@ class TestSDWANCredentialSets:
 
         result = detect_controller_type()
         assert result == "SDWAN"
+
+        # Should fall back to session auth
+        cred = get_matched_credential_set("SDWAN")
+        assert cred is not None
+        assert cred.auth_method == "session"
 
     def test_url_only_is_partial(self) -> None:
         """SDWAN_URL alone (no token, no username/password) is partial."""
@@ -634,3 +672,25 @@ class TestSDWANCredentialSets:
         error_msg = str(exc_info.value)
         assert "API Token (20.18+)" in error_msg
         assert "Username/Password" in error_msg
+
+    def test_get_matched_credential_set_before_detection(self) -> None:
+        """get_matched_credential_set returns None before detect_controller_type runs."""
+        assert get_matched_credential_set("SDWAN") is None
+
+    def test_credential_set_auth_method_default(self) -> None:
+        """CredentialSet.auth_method defaults to 'session'."""
+        cs = CredentialSet(env_vars=["X_URL", "X_USER", "X_PASS"], label="test")
+        assert cs.auth_method == "session"
+
+    def test_aci_matched_credential_set(self) -> None:
+        """ACI detection stores matched credential set with session auth."""
+        os.environ["ACI_URL"] = "https://apic.example.com"
+        os.environ["ACI_USERNAME"] = "admin"
+        os.environ["ACI_PASSWORD"] = "password"
+
+        detect_controller_type()
+
+        cred = get_matched_credential_set("ACI")
+        assert cred is not None
+        assert cred.auth_method == "session"
+        assert cred.label == "Username/Password"

--- a/tests/utils/test_controller.py
+++ b/tests/utils/test_controller.py
@@ -20,6 +20,7 @@ from nac_test.utils.controller import (
     get_controller_url,
     get_matched_credential_set,
 )
+from nac_test.utils.environment import EnvironmentValidator
 
 
 @pytest.fixture(autouse=True)
@@ -609,3 +610,87 @@ class TestSDWANCredentialSets:
         assert cred is not None
         assert cred.auth_method == "session"
         assert cred.label == "Username/Password"
+
+
+class TestGetControllerUrlSDWAN:
+    """Tests for get_controller_url with multi-credential-set controllers (SDWAN)."""
+
+    def test_sdwan_url_returned_when_set(self) -> None:
+        """get_controller_url returns SDWAN_URL directly from url_env_var."""
+        os.environ["SDWAN_URL"] = "https://vmanage.example.com"
+        os.environ["SDWAN_API_TOKEN"] = "some-token"
+
+        url = get_controller_url("SDWAN")
+        assert url == "https://vmanage.example.com"
+
+    def test_sdwan_does_not_return_token_when_url_empty(self) -> None:
+        """get_controller_url raises KeyError when SDWAN_URL is empty, not returning token."""
+        os.environ["SDWAN_URL"] = ""
+        os.environ["SDWAN_API_TOKEN"] = "eyJhbGciOiJSUzI1NiJ9.test.sig"
+
+        with pytest.raises(KeyError) as exc_info:
+            get_controller_url("SDWAN")
+
+        assert "SDWAN_URL" in str(exc_info.value)
+
+    def test_sdwan_does_not_return_token_when_url_whitespace(self) -> None:
+        """get_controller_url raises KeyError when SDWAN_URL is whitespace-only."""
+        os.environ["SDWAN_URL"] = "   "
+        os.environ["SDWAN_API_TOKEN"] = "some-token"
+
+        with pytest.raises(KeyError) as exc_info:
+            get_controller_url("SDWAN")
+
+        assert "SDWAN_URL" in str(exc_info.value)
+
+    def test_sdwan_does_not_return_username_when_url_missing(self) -> None:
+        """get_controller_url raises KeyError, not returning username/password vars."""
+        os.environ["SDWAN_USERNAME"] = "admin"
+        os.environ["SDWAN_PASSWORD"] = "password"
+
+        with pytest.raises(KeyError) as exc_info:
+            get_controller_url("SDWAN")
+
+        assert "SDWAN_URL" in str(exc_info.value)
+
+
+class TestValidateControllerEnvMultiCredSet:
+    """Tests for validate_controller_env with multi-credential-set controllers."""
+
+    def test_sdwan_passes_with_username_password_only(self) -> None:
+        """validate_controller_env passes when only username/password set (not token)."""
+        os.environ["SDWAN_URL"] = "https://vmanage.example.com"
+        os.environ["SDWAN_USERNAME"] = "admin"
+        os.environ["SDWAN_PASSWORD"] = "password"
+
+        # Should not raise
+        EnvironmentValidator().validate_controller_env("SDWAN")
+
+    def test_sdwan_passes_with_api_token_only(self) -> None:
+        """validate_controller_env passes when only API token set."""
+        os.environ["SDWAN_URL"] = "https://vmanage.example.com"
+        os.environ["SDWAN_API_TOKEN"] = "eyJhbGciOiJSUzI1NiJ9.test.sig"
+
+        # Should not raise
+        EnvironmentValidator().validate_controller_env("SDWAN")
+
+    def test_sdwan_exits_when_no_credential_set_satisfied(self) -> None:
+        """validate_controller_env exits with all credential sets listed."""
+        os.environ["SDWAN_URL"] = "https://vmanage.example.com"
+        # No token, no username/password
+
+        with pytest.raises(SystemExit) as exc_info:
+            EnvironmentValidator().validate_controller_env("SDWAN")
+
+        error_msg = str(exc_info.value)
+        assert "SDWAN: incomplete credentials" in error_msg
+        assert "API Token (20.18+)" in error_msg
+        assert "Username/Password" in error_msg
+
+    def test_sdwan_exits_when_nothing_set(self) -> None:
+        """validate_controller_env exits when no SDWAN vars are set at all."""
+        with pytest.raises(SystemExit) as exc_info:
+            EnvironmentValidator().validate_controller_env("SDWAN")
+
+        error_msg = str(exc_info.value)
+        assert "SDWAN" in error_msg

--- a/tests/utils/test_controller.py
+++ b/tests/utils/test_controller.py
@@ -656,6 +656,9 @@ class TestSDWANCredentialSets:
 
         error_msg = str(exc_info.value)
         assert "Incomplete controller credentials detected" in error_msg
+        assert "SDWAN: incomplete credentials" in error_msg
+        assert "API Token (20.18+)" in error_msg
+        assert "Username/Password" in error_msg
 
     def test_incomplete_error_shows_credential_set_options(self) -> None:
         """Incomplete SDWAN credentials should list both credential set options."""

--- a/tests/utils/test_controller.py
+++ b/tests/utils/test_controller.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from nac_test.utils.controller import (
-    CREDENTIAL_PATTERNS,
+    CONTROLLER_REGISTRY,
     _find_credential_sets,
     _format_multiple_credentials_error,
     _format_no_credentials_error,
@@ -28,10 +28,11 @@ class TestControllerDetection:
         # Store original environment
         original_env = os.environ.copy()
 
-        # Remove all controller-related variables
-        for controller_vars in CREDENTIAL_PATTERNS.values():
-            for var in controller_vars:
-                os.environ.pop(var, None)
+        # Remove all controller-related variables (all credential sets)
+        for config in CONTROLLER_REGISTRY.values():
+            for cred_set in config.credential_sets:
+                for var in cred_set.env_vars:
+                    os.environ.pop(var, None)
 
         # Also remove legacy CONTROLLER_TYPE if present
         os.environ.pop("CONTROLLER_TYPE", None)
@@ -82,15 +83,17 @@ class TestControllerDetection:
 
         error_msg = str(exc_info.value)
         assert "Multiple controller credentials detected: ACI, SDWAN" in error_msg
-        assert "unset SDWAN_URL SDWAN_USERNAME SDWAN_PASSWORD" in error_msg
+        # SDWAN has multiple credential sets — unset should include all env vars
+        assert "unset SDWAN_URL SDWAN_API_TOKEN SDWAN_USERNAME SDWAN_PASSWORD" in error_msg
         assert "unset ACI_URL ACI_USERNAME ACI_PASSWORD" in error_msg
 
     def test_no_credentials_error(self) -> None:
         """Test error when no controller credentials are found."""
         # Ensure environment is completely clean
-        for controller_vars in CREDENTIAL_PATTERNS.values():
-            for var in controller_vars:
-                os.environ.pop(var, None)
+        for config in CONTROLLER_REGISTRY.values():
+            for cred_set in config.credential_sets:
+                for var in cred_set.env_vars:
+                    os.environ.pop(var, None)
 
         with pytest.raises(ValueError) as exc_info:
             detect_controller_type()
@@ -166,9 +169,10 @@ class TestHelperFunctions:
         """Clean environment variables before and after each test."""
         original_env = os.environ.copy()
 
-        for controller_vars in CREDENTIAL_PATTERNS.values():
-            for var in controller_vars:
-                os.environ.pop(var, None)
+        for config in CONTROLLER_REGISTRY.values():
+            for cred_set in config.credential_sets:
+                for var in cred_set.env_vars:
+                    os.environ.pop(var, None)
 
         yield
 
@@ -226,10 +230,9 @@ class TestHelperFunctions:
 
         assert "Multiple controller credentials detected: ACI, SDWAN, CC" in error_msg
         assert "To use ACI only:" in error_msg
-        assert (
-            "unset SDWAN_URL SDWAN_USERNAME SDWAN_PASSWORD CC_URL CC_USERNAME CC_PASSWORD"
-            in error_msg
-        )
+        # SDWAN has two credential sets, so all env vars from both sets appear
+        assert "unset SDWAN_URL SDWAN_API_TOKEN SDWAN_USERNAME SDWAN_PASSWORD" in error_msg
+        assert "CC_URL CC_USERNAME CC_PASSWORD" in error_msg
         assert "To use SDWAN only:" in error_msg
         assert (
             "unset ACI_URL ACI_USERNAME ACI_PASSWORD CC_URL CC_USERNAME CC_PASSWORD"
@@ -260,9 +263,10 @@ class TestEdgeCases:
         """Clean environment variables before and after each test."""
         original_env = os.environ.copy()
 
-        for controller_vars in CREDENTIAL_PATTERNS.values():
-            for var in controller_vars:
-                os.environ.pop(var, None)
+        for config in CONTROLLER_REGISTRY.values():
+            for cred_set in config.credential_sets:
+                for var in cred_set.env_vars:
+                    os.environ.pop(var, None)
 
         yield
 
@@ -396,9 +400,10 @@ class TestIOSXEAlternativeURLEnvVar:
         original_env = os.environ.copy()
 
         # Remove all controller-related variables
-        for controller_vars in CREDENTIAL_PATTERNS.values():
-            for var in controller_vars:
-                os.environ.pop(var, None)
+        for config in CONTROLLER_REGISTRY.values():
+            for cred_set in config.credential_sets:
+                for var in cred_set.env_vars:
+                    os.environ.pop(var, None)
 
         # Also remove IOSXE_HOST alternative
         os.environ.pop("IOSXE_HOST", None)
@@ -489,9 +494,10 @@ class TestGetControllerUrl:
         """Clean environment variables before and after each test."""
         original_env = os.environ.copy()
 
-        for controller_vars in CREDENTIAL_PATTERNS.values():
-            for var in controller_vars:
-                os.environ.pop(var, None)
+        for config in CONTROLLER_REGISTRY.values():
+            for cred_set in config.credential_sets:
+                for var in cred_set.env_vars:
+                    os.environ.pop(var, None)
 
         os.environ.pop("IOSXE_HOST", None)
 
@@ -535,3 +541,96 @@ class TestGetControllerUrl:
             get_controller_url("NONEXISTENT")
 
         assert "NONEXISTENT_URL" in str(exc_info.value)
+
+
+class TestSDWANCredentialSets:
+    """Test SDWAN controller detection with multiple credential sets.
+
+    SDWAN supports two credential methods:
+    1. API Token (20.18+): SDWAN_URL + SDWAN_API_TOKEN  (first — wins when both present)
+    2. Username/Password: SDWAN_URL + SDWAN_USERNAME + SDWAN_PASSWORD
+    """
+
+    @pytest.fixture(autouse=True)
+    def clean_environment(self) -> Generator[None, None, None]:
+        """Clean environment variables before and after each test."""
+        original_env = os.environ.copy()
+
+        for config in CONTROLLER_REGISTRY.values():
+            for cred_set in config.credential_sets:
+                for var in cred_set.env_vars:
+                    os.environ.pop(var, None)
+
+        yield
+
+        os.environ.clear()
+        os.environ.update(original_env)
+
+    def test_detect_sdwan_with_api_token(self) -> None:
+        """Test SDWAN detection with API token credentials."""
+        os.environ["SDWAN_URL"] = "https://vmanage.example.com"
+        os.environ["SDWAN_API_TOKEN"] = "eyJhbGciOiJSUzI1NiJ9.test.sig"
+
+        result = detect_controller_type()
+        assert result == "SDWAN"
+
+    def test_detect_sdwan_with_username_password(self) -> None:
+        """Test SDWAN detection with traditional username/password."""
+        os.environ["SDWAN_URL"] = "https://vmanage.example.com"
+        os.environ["SDWAN_USERNAME"] = "admin"
+        os.environ["SDWAN_PASSWORD"] = "password"
+
+        result = detect_controller_type()
+        assert result == "SDWAN"
+
+    def test_api_token_takes_priority(self) -> None:
+        """When both credential sets are satisfied, token set wins (listed first)."""
+        os.environ["SDWAN_URL"] = "https://vmanage.example.com"
+        os.environ["SDWAN_API_TOKEN"] = "eyJhbGciOiJSUzI1NiJ9.test.sig"
+        os.environ["SDWAN_USERNAME"] = "admin"
+        os.environ["SDWAN_PASSWORD"] = "password"
+
+        # Should still detect exactly one SDWAN (not duplicate)
+        result = detect_controller_type()
+        assert result == "SDWAN"
+
+    def test_partial_token_set_falls_back_to_password(self) -> None:
+        """When SDWAN_API_TOKEN is missing but username/password present, detect SDWAN."""
+        os.environ["SDWAN_URL"] = "https://vmanage.example.com"
+        # No SDWAN_API_TOKEN
+        os.environ["SDWAN_USERNAME"] = "admin"
+        os.environ["SDWAN_PASSWORD"] = "password"
+
+        result = detect_controller_type()
+        assert result == "SDWAN"
+
+    def test_empty_api_token_falls_back_to_password(self) -> None:
+        """Empty SDWAN_API_TOKEN should not satisfy the token credential set."""
+        os.environ["SDWAN_URL"] = "https://vmanage.example.com"
+        os.environ["SDWAN_API_TOKEN"] = ""
+        os.environ["SDWAN_USERNAME"] = "admin"
+        os.environ["SDWAN_PASSWORD"] = "password"
+
+        result = detect_controller_type()
+        assert result == "SDWAN"
+
+    def test_url_only_is_partial(self) -> None:
+        """SDWAN_URL alone (no token, no username/password) is partial."""
+        os.environ["SDWAN_URL"] = "https://vmanage.example.com"
+
+        with pytest.raises(ValueError) as exc_info:
+            detect_controller_type()
+
+        error_msg = str(exc_info.value)
+        assert "Incomplete controller credentials detected" in error_msg
+
+    def test_incomplete_error_shows_credential_set_options(self) -> None:
+        """Incomplete SDWAN credentials should list both credential set options."""
+        os.environ["SDWAN_URL"] = "https://vmanage.example.com"
+
+        with pytest.raises(ValueError) as exc_info:
+            detect_controller_type()
+
+        error_msg = str(exc_info.value)
+        assert "API Token (20.18+)" in error_msg
+        assert "Username/Password" in error_msg


### PR DESCRIPTION
## Description

Introduces the `CredentialSet` dataclass and multi-credential-set support to `CONTROLLER_REGISTRY`, replacing the old `CREDENTIAL_PATTERNS` dictionary. Each controller can now define multiple ordered credential combinations (e.g., SDWAN supports both API token and username/password). The first fully-satisfied set wins, and the winning `CredentialSet` is exposed via `get_matched_credential_set()` for downstream auth adapters in nac-test-pyats-common.

Also simplifies `_find_credential_sets()` — removes per-variable present/missing tracking (`CredentialSetStatus` TypedDict) in favor of a simple boolean `has_any_var` check. Incomplete credential error messages now show "incomplete credentials" with all accepted credential sets listed, rather than reporting specific missing variables (the code to keep the previous behavior is more complex, with little gain, really [edited oboehmer]).

## Closes

- https://github.com/netascode/nac-test/issues/854 (feature request)

## Related Issue(s)

- Related to nac-test-pyats-common issue : https://github.com/netascode/nac-test-pyats-common/issues/34
- Parent feature request - - Internal NAC-SDWAN issue #1110

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring / Technical debt (internal improvements with no user-facing changes)
- [x] Documentation update
- [ ] Chore (build process, CI, tooling, dependencies)
- [ ] Other (please describe):

## Test Framework Affected

- [ ] PyATS
- [ ] Robot Framework
- [x] Both
- [ ] N/A (not test-framework specific)

## Network as Code (NaC) Architecture Affected

- [ ] ACI (APIC)
- [ ] NDO (Nexus Dashboard Orchestrator)
- [ ] NDFC / VXLAN-EVPN (Nexus Dashboard Fabric Controller)
- [x] Catalyst SD-WAN (SDWAN Manager / vManage)
- [ ] Catalyst Center (DNA Center)
- [ ] ISE (Identity Services Engine)
- [ ] FMC (Firepower Management Center)
- [ ] Meraki (Cloud-managed)
- [ ] NX-OS (Nexus Direct-to-Device)
- [ ] IOS-XE (Direct-to-Device)
- [ ] IOS-XR (Direct-to-Device)
- [ ] Hyperfabric
- [x] All architectures
- [ ] N/A (architecture-agnostic)

## Platform Tested

> nac-test supports macOS and Linux only

- [x] macOS (version tested: macOS with Python 3.13.5)
- [ ] Linux (distro/version tested: )

## Key Changes

- **`nac_test/utils/controller.py`** (294 lines changed):
  - Added `CredentialSet` dataclass with `env_vars`, `label`, and `auth_method` attributes
  - Added `credential_sets` (ordered list)
  - Removed `CREDENTIAL_PATTERNS` backward-compatible dictionary
  - Removed `CredentialSetStatus` TypedDict
  - SDWAN registry entry now has two credential sets: API Token (20.18+, `auth_method="token"`) and Username/Password (`auth_method="session"`)
  - `_find_credential_sets()`: simplified to track `has_any_var` boolean instead of per-variable present/missing lists; returns `tuple[list[str], list[str], dict[str, CredentialSet]]`
  - `detect_controller_type()`: stores winning `CredentialSet` in module-level `_matched_credential_sets` cache; incomplete error messages now list all accepted credential sets
  - Added `get_matched_credential_set()` — public API for nac-test-pyats-common to retrieve the winning credential set and determine `auth_method`
- **`nac_test/utils/environment.py`** (33 lines changed):
  - `validate_controller_env()`: checks credential sets with early return before requiring username/password
- **`tests/utils/test_controller.py`** (227 lines changed):
  - 43 unit tests covering credential set matching, multi-set priority, partial detection, IOSXE alternative URLs, error formatting, and `get_matched_credential_set()` API
  - Updated assertions from `"missing X_VAR"` → `"incomplete credentials"` format
- **`tests/unit/pyats_core/common/test_base_test_iosxe_credentials.py`**:
  - Updated 1 assertion to match new "incomplete credentials" error format
- **`dev-docs/PRD_AND_ARCHITECTURE.md`** (137 lines changed):
  - Removed stale `CREDENTIAL_PATTERNS` definition
  - Updated detection algorithm pseudocode (`partial_sets` → `partial_controllers`)
  - Updated flow diagram node from "Track best partial match" → "Track as partial if any env_var was set"
- **`CHANGELOG.md`**: Added credential set support entry
- **`README.md`**: Updated credential documentation

## Testing Done

- [x] Unit tests added/updated
- [ ] Integration tests performed
- [x] Manual testing performed:
  - [x] PyATS tests executed successfully
  - [x] Robot Framework tests executed successfully
  - [ ] D2D/SSH tests executed successfully (if applicable)
  - [x] HTML reports generated correctly
- [x] All existing tests pass (`pytest` / `pre-commit run -a`)

### Test Commands Used

```bash
# 971 unit tests pass (917 unit + 54 utils/test_controller.py)
cd nac-test && python -m pytest tests/utils/test_controller.py tests/unit/ -x -q

# Verified token credential set detection
export SDWAN_URL=https://x.x.x.x
export SDWAN_API_TOKEN=<jwt_token>
nac-test -d standard -d standard_2015 -d defaults.yaml -f jinja_filters -t test_aaa_2018_token_auth -o results-robot
nac-test -d standard -d standard_2015 -d defaults.yaml -f jinja_filters -t tests -o result-pyats --pyats

# Verified credential set matching
python -c "
from nac_test.utils.controller import detect_controller_type, get_matched_credential_set
ct = detect_controller_type()
cs = get_matched_credential_set(ct)
print(f'{ct}: {cs.label} (auth_method={cs.auth_method})')
"
# Output: SDWAN: API Token (20.18+) (auth_method=token)
```

## Checklist

- [x] Code follows project style guidelines (`pre-commit run -a` passes)
- [x] Self-review of code completed
- [x] Code is commented where necessary (especially complex logic)
- [x] Documentation updated (if applicable)
- [ ] No new warnings introduced
- [ ] Changes work on both macOS and Linux
- [x] CHANGELOG.md updated (if applicable)

## Additional Notes

- The _matched_credential_sets module-level dict is re-populated in each PyATS subprocess via NACTestBase.setup() → detect_controller_type(). The env vars (which are inherited across subprocess boundaries) are the real source of truth; the dict is an in-process cache.
- Credential set order in CONTROLLER_REGISTRY determines priority: for SDWAN, token auth is checked first (newer method for 20.18+), falling back to username/password session auth. Users can force session auth by unsetting SDWAN_API_TOKEN.

## Additional Testing Done

**PYATS Tests :-** 

1. No env vars
```
ERROR - No controller credentials found in environment

❌ Controller detection failed:
No controller credentials found in environment.

Controller credentials are required for ALL test types (API and D2D).
The framework uses these to determine the architecture context.

Please set environment variables for ONE of the following controller types:

ACI:
  export ACI_URL=<value>
  export ACI_USERNAME=<value>
  export ACI_PASSWORD=<value>

SDWAN:
  (API Token (20.18+)):
  export SDWAN_URL=<value>
  export SDWAN_API_TOKEN=<value>
  Or
  (Username/Password):
  export SDWAN_URL=<value>
  export SDWAN_USERNAME=<value>
  export SDWAN_PASSWORD=<value>

CC:
  export CC_URL=<value>
  export CC_USERNAME=<value>
  export CC_PASSWORD=<value>

MERAKI:
  export MERAKI_URL=<value>
  export MERAKI_USERNAME=<value>
  export MERAKI_PASSWORD=<value>

FMC:
  export FMC_URL=<value>
  export FMC_USERNAME=<value>
  export FMC_PASSWORD=<value>

ISE:
  export ISE_URL=<value>
  export ISE_USERNAME=<value>
  export ISE_PASSWORD=<value>

IOSXE:
  export IOSXE_URL=<value>

Example for ACI:
  export ACI_URL=https://apic.example.com
  export ACI_USERNAME=admin
  export ACI_PASSWORD=yourpassword

Note: Set credentials for only ONE controller type at a time.
```
2. Only SDWAN URL:
```
❌ Controller detection failed:
Incomplete controller credentials detected:
  - SDWAN: incomplete credentials
    Accepted credential sets:
      - API Token (20.18+): SDWAN_URL + SDWAN_API_TOKEN
      - Username/Password: SDWAN_URL + SDWAN_USERNAME + SDWAN_PASSWORD

Please provide ALL required environment variables for your controller type.
```
3. Only SDWAN URL and User
```
ERROR - Incomplete credentials: ['SDWAN']

❌ Controller detection failed:
Incomplete controller credentials detected:
  - SDWAN: incomplete credentials
    Accepted credential sets:
      - API Token (20.18+): SDWAN_URL + SDWAN_API_TOKEN
      - Username/Password: SDWAN_URL + SDWAN_USERNAME + SDWAN_PASSWORD

Please provide ALL required environment variables for your controller type.
```
4. Only SDWAN URL and pass
```
ERROR - Incomplete credentials: ['SDWAN']

❌ Controller detection failed:
Incomplete controller credentials detected:
  - SDWAN: incomplete credentials
    Accepted credential sets:
      - API Token (20.18+): SDWAN_URL + SDWAN_API_TOKEN
      - Username/Password: SDWAN_URL + SDWAN_USERNAME + SDWAN_PASSWORD

Please provide ALL required environment variables for your controller type.
```
5. SDWAN URL, user and wrong pass
Failed testcases

6. Only SDWAN URL, user and right pass
Passed testcases

7. Only SDWAN URL and right token
Pass testcases

8. Only SDWAN URL and wrong token header
Failed testcases

9. Only SDWAN URL and wrong token payload
Failed testcases

10. Only SDWAN URL and wrong token signature
Failed testcases

11. User, SDWAN URL, right password and right token
Passed testcases

12. User, SDWAN URL, wrong pass and right token
Passed testcases

13. User, SDWAN URL, right password and wrong token
Failed testcases

**Robot tests :-**

14. No env var
Failure

15. Only SDWAN URL
Failure

16. Only user and SDWAN URL
Failure

17. Only user, good  pass and SDWAN URL 
Pass

18. Only user, bad pass and SDWAN URL
Failure

19. Only pass and SDWAN URL
Failure

20. SDWAN URL and good token
Pass

21. SDWAN URL and wrong token header
Failure

22. SDWAN URL and wrong token payload
Failure

23. SDWAN URL and wrong token signature
Failure

24. SDWAN URL and user, wrong pass and right token
pass

25. SDWAN URL and user, right pass and wrong token
Fail

26. SDWAN URL and user, right pass and right token
Pass