### PR TITLE
Update `iterate_list_chunked` to support dict as parent_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- robot rendering: added support for dicts as parent_key in `iterate_list_chunked` 
+
 # 2.0.0
 
 ## Major Features

--- a/README.md
+++ b/README.md
@@ -585,6 +585,53 @@ tests
     └── test1_001.robot
 ```
 
+The OBJECT_PATH may be either a single-level path pointing directly at a list, or a two-level dotted path (`<PARENT>.<CHILD>`) where the parent is a list or a dictionary and the child is the list to be chunked. When the parent is a dictionary, only the child list is split by CHUNK_SIZE while sibling keys under the same parent are preserved untouched in every chunk.
+
+When the parent is a list, the child objects are counted across all parent items and chunked globally: each chunk holds up to CHUNK_SIZE child objects, carrying along only the parent items those children belong to (with the child list sliced accordingly). A parent item spanning a chunk boundary appears in both chunks, each time with just its portion of the child list.
+
+For example, given the following input with an OBJECT_PATH of `services.endpoints` and a CHUNK_SIZE of `2`:
+
+```yaml
+services:
+  - name: s1
+    endpoints:
+      - name: e1
+      - name: e2
+      - name: e3
+  - name: s2
+    endpoints:
+      - name: e4
+  - name: s3
+    endpoints:
+      - name: e5
+```
+
+three chunks are produced:
+
+```yaml
+# chunk 1
+services:
+  - name: s1
+    endpoints:
+      - name: e1
+      - name: e2
+
+# chunk 2
+services:
+  - name: s1
+    endpoints:
+      - name: e3
+  - name: s2
+    endpoints:
+      - name: e4
+
+# chunk 3
+services:
+  - name: s3
+    endpoints:
+      - name: e5
+```
+
 
 ## Select Test Cases By Tag
 

--- a/nac_test/robot/robot_writer.py
+++ b/nac_test/robot/robot_writer.py
@@ -189,6 +189,22 @@ class RobotWriter:
         elif len(path_parts) == 2:
             # Nested case: collect objects from nested structure
             parent_key, child_key = path_parts
+            parent = data.get(parent_key)
+
+            # Check if parent is a dict
+            if isinstance(parent, dict):
+                objects = parent.get(child_key, [])
+                if not isinstance(objects, list):
+                    return [data]
+                chunked_data = []
+                for i in range(0, len(objects), chunk_size):
+                    chunked_item = copy.deepcopy(data)
+                    chunked_item[parent_key][child_key] = objects[i : i + chunk_size]
+                    chunked_data.append(chunked_item)
+
+                return chunked_data
+
+            # Continue with assumption that parent is a list
             all_objects = []
 
             # Collect all nested objects with their parent context

--- a/nac_test/robot/robot_writer.py
+++ b/nac_test/robot/robot_writer.py
@@ -170,11 +170,13 @@ class RobotWriter:
             List of modified data structures, each containing a subset of
             objects, or ``[data]`` unchanged if the path does not hold a list
         """
-        container = data
+        container: Any = data
         for key in path_parts[:-1]:
-            container = container[key]
-        objects = container.get(path_parts[-1], [])
-        if not isinstance(objects, list):
+            container = container.get(key)
+            if not isinstance(container, dict):
+                return [data]
+        objects = container.get(path_parts[-1])
+        if not isinstance(objects, list) or not objects:
             return [data]
 
         chunked_data = []

--- a/nac_test/robot/robot_writer.py
+++ b/nac_test/robot/robot_writer.py
@@ -260,7 +260,7 @@ class RobotWriter:
                     chunked_data.append(chunked_item)
 
                 return chunked_data
-            
+
             else:
                 raise ValueError(
                     f"Parent key '{parent_key}' is neither a list nor a dict in the data structure."

--- a/nac_test/robot/robot_writer.py
+++ b/nac_test/robot/robot_writer.py
@@ -150,6 +150,44 @@ class RobotWriter:
                 return Path(*paths[:-1], "_" + paths[-1])
         return Path(os.path.join(*paths))
 
+    def _chunk_list_at_path(
+        self,
+        data: dict[str, Any],
+        path_parts: list[str],
+        chunk_size: int,
+    ) -> list[dict[str, Any]]:
+        """Split a list found at a known key path into chunks.
+
+        Navigates ``data`` along ``path_parts`` to a list and, for each chunk,
+        creates a deep copy of ``data`` with that list replaced by the chunk.
+
+        Args:
+            data: The full data structure to copy for each chunk
+            path_parts: Keys navigating from ``data`` to the list to chunk
+            chunk_size: Number of objects per chunk
+
+        Returns:
+            List of modified data structures, each containing a subset of
+            objects, or ``[data]`` unchanged if the path does not hold a list
+        """
+        container = data
+        for key in path_parts[:-1]:
+            container = container[key]
+        objects = container.get(path_parts[-1], [])
+        if not isinstance(objects, list):
+            return [data]
+
+        chunked_data = []
+        for i in range(0, len(objects), chunk_size):
+            chunked_item = copy.deepcopy(data)
+            target = chunked_item
+            for key in path_parts[:-1]:
+                target = target[key]
+            target[path_parts[-1]] = objects[i : i + chunk_size]
+            chunked_data.append(chunked_item)
+
+        return chunked_data
+
     def _chunk_nested_objects(
         self, data: dict[str, Any], object_path: str, chunk_size: int
     ) -> list[dict[str, Any]]:
@@ -168,87 +206,65 @@ class RobotWriter:
         # Handle simple path (single level) vs nested path
         if len(path_parts) == 1:
             # Simple case: chunk objects directly from the data
-            objects = data.get(path_parts[0], [])
-            if not isinstance(objects, list):
-                return [data]  # Return original if not a list
-
-            # Split objects into chunks
-            chunks = []
-            for i in range(0, len(objects), chunk_size):
-                chunks.append(objects[i : i + chunk_size])
-
-            # Create modified data for each chunk
-            chunked_data = []
-            for chunk in chunks:
-                chunked_item = copy.deepcopy(data)
-                chunked_item[path_parts[0]] = chunk
-                chunked_data.append(chunked_item)
-
-            return chunked_data
+            return self._chunk_list_at_path(data, path_parts, chunk_size)
 
         elif len(path_parts) == 2:
-            # Nested case: collect objects from nested structure
             parent_key, child_key = path_parts
             parent = data.get(parent_key)
 
-            # Check if parent is a dict
             if isinstance(parent, dict):
-                objects = parent.get(child_key, [])
-                if not isinstance(objects, list):
-                    return [data]
+                return self._chunk_list_at_path(data, path_parts, chunk_size)
+
+            elif isinstance(parent, list):
+                all_objects = []
+
+                # Collect all nested objects with their parent context
+                for parent in data.get(parent_key, []):
+                    parent_name = parent.get("name", "")
+                    for obj in parent.get(child_key, []):
+                        all_objects.append((parent_name, obj))
+
+                # Split into chunks
+                object_chunks = []
+                for i in range(0, len(all_objects), chunk_size):
+                    object_chunks.append(all_objects[i : i + chunk_size])
+
+                # Create modified data for each chunk
                 chunked_data = []
-                for i in range(0, len(objects), chunk_size):
+                for chunk in object_chunks:
                     chunked_item = copy.deepcopy(data)
-                    chunked_item[parent_key][child_key] = objects[i : i + chunk_size]
+
+                    # Group objects by parent for this chunk
+                    parent_objects: dict[str, list[Any]] = {}
+                    for parent_name, obj in chunk:
+                        if parent_name not in parent_objects:
+                            parent_objects[parent_name] = []
+                        parent_objects[parent_name].append(obj)
+
+                    # Update parent objects to only include objects from this chunk
+                    if parent_key in chunked_item:
+                        for parent in chunked_item[parent_key]:
+                            parent_name = parent.get("name", "")
+                            if parent_name in parent_objects:
+                                parent[child_key] = parent_objects[parent_name]
+                            else:
+                                parent[child_key] = []
+
+                        # Remove parents that have no objects in this chunk
+                        chunked_item[parent_key] = [
+                            parent
+                            for parent in chunked_item[parent_key]
+                            if parent.get(child_key, [])
+                        ]
+
                     chunked_data.append(chunked_item)
 
                 return chunked_data
-
-            # Continue with assumption that parent is a list
-            all_objects = []
-
-            # Collect all nested objects with their parent context
-            for parent in data.get(parent_key, []):
-                parent_name = parent.get("name", "")
-                for obj in parent.get(child_key, []):
-                    all_objects.append((parent_name, obj))
-
-            # Split into chunks
-            object_chunks = []
-            for i in range(0, len(all_objects), chunk_size):
-                object_chunks.append(all_objects[i : i + chunk_size])
-
-            # Create modified data for each chunk
-            chunked_data = []
-            for chunk in object_chunks:
-                chunked_item = copy.deepcopy(data)
-
-                # Group objects by parent for this chunk
-                parent_objects: dict[str, list[Any]] = {}
-                for parent_name, obj in chunk:
-                    if parent_name not in parent_objects:
-                        parent_objects[parent_name] = []
-                    parent_objects[parent_name].append(obj)
-
-                # Update parent objects to only include objects from this chunk
-                if parent_key in chunked_item:
-                    for parent in chunked_item[parent_key]:
-                        parent_name = parent.get("name", "")
-                        if parent_name in parent_objects:
-                            parent[child_key] = parent_objects[parent_name]
-                        else:
-                            parent[child_key] = []
-
-                    # Remove parents that have no objects in this chunk
-                    chunked_item[parent_key] = [
-                        parent
-                        for parent in chunked_item[parent_key]
-                        if parent.get(child_key, [])
-                    ]
-
-                chunked_data.append(chunked_item)
-
-            return chunked_data
+            
+            else:
+                raise ValueError(
+                    f"Parent key '{parent_key}' is neither a list nor a dict in the data structure."
+                )
 
         else:
             # More complex nesting not supported yet

--- a/tests/integration/fixtures/data_list_chunked_dict/data.yaml
+++ b/tests/integration/fixtures/data_list_chunked_dict/data.yaml
@@ -1,0 +1,27 @@
+---
+fmc:
+  domains:
+    - name: Global
+      objects:
+        hosts:
+          - name: host1
+            ip: 10.0.0.1
+          - name: host2
+            ip: 10.0.0.2
+          - name: host3
+            ip: 10.0.0.3
+          - name: host4
+            ip: 10.0.0.4
+          - name: host5
+            ip: 10.0.0.5
+        networks:
+          - name: net1
+            cidr: 10.0.0.0/24
+    - name: Global/Child
+      objects:
+        hosts:
+          - name: host6
+            ip: 10.1.0.1
+        networks:
+          - name: net2
+            cidr: 10.1.0.0/24

--- a/tests/integration/fixtures/data_list_chunked_dict/data.yaml
+++ b/tests/integration/fixtures/data_list_chunked_dict/data.yaml
@@ -16,7 +16,7 @@ fmc:
             ip: 10.0.0.5
         networks:
           - name: net1
-            cidr: 10.0.0.0/24
+            prefix: 10.0.0.0/24
     - name: Global/Child
       objects:
         hosts:
@@ -24,4 +24,9 @@ fmc:
             ip: 10.1.0.1
         networks:
           - name: net2
-            cidr: 10.1.0.0/24
+            prefix: 10.1.0.0/24
+    - name: Global/Child2
+      objects:
+        networks:
+          - name: net3
+            prefix: 10.2.0.0/24

--- a/tests/integration/fixtures/templates_list_chunked_dict/expected_content.yaml
+++ b/tests/integration/fixtures/templates_list_chunked_dict/expected_content.yaml
@@ -64,3 +64,14 @@ Global/Child/test1_001.robot: |
 
   Test Global/Child Network net2
       Should Be Equal   10.1.0.0/24   10.1.0.0/24
+
+Global/Child2/test1_001.robot: |
+  *** Settings ***
+  Documentation   Test1
+
+  *** Test Cases ***
+
+  Test Global/Child2
+
+  Test Global/Child2 Network net3
+      Should Be Equal   10.2.0.0/24   10.2.0.0/24

--- a/tests/integration/fixtures/templates_list_chunked_dict/expected_content.yaml
+++ b/tests/integration/fixtures/templates_list_chunked_dict/expected_content.yaml
@@ -1,0 +1,66 @@
+# used to verify the actual content of the rendered file
+#
+# Dict-parent chunking (object_path "objects.hosts"): 5 hosts in the Global
+# domain at chunk size 2 -> 3 chunks of 2, 2, 1. The sibling "networks" list
+# under the same dict parent is preserved untouched in every chunk.
+Global/test1_001.robot: |
+  *** Settings ***
+  Documentation   Test1
+
+  *** Test Cases ***
+
+  Test Global
+
+  Test Global Host host1
+      Should Be Equal   10.0.0.1   10.0.0.1
+
+  Test Global Host host2
+      Should Be Equal   10.0.0.2   10.0.0.2
+
+  Test Global Network net1
+      Should Be Equal   10.0.0.0/24   10.0.0.0/24
+
+Global/test1_002.robot: |
+  *** Settings ***
+  Documentation   Test1
+
+  *** Test Cases ***
+
+  Test Global
+
+  Test Global Host host3
+      Should Be Equal   10.0.0.3   10.0.0.3
+
+  Test Global Host host4
+      Should Be Equal   10.0.0.4   10.0.0.4
+
+  Test Global Network net1
+      Should Be Equal   10.0.0.0/24   10.0.0.0/24
+
+Global/test1_003.robot: |
+  *** Settings ***
+  Documentation   Test1
+
+  *** Test Cases ***
+
+  Test Global
+
+  Test Global Host host5
+      Should Be Equal   10.0.0.5   10.0.0.5
+
+  Test Global Network net1
+      Should Be Equal   10.0.0.0/24   10.0.0.0/24
+
+Global/Child/test1_001.robot: |
+  *** Settings ***
+  Documentation   Test1
+
+  *** Test Cases ***
+
+  Test Global/Child
+
+  Test Global/Child Host host6
+      Should Be Equal   10.1.0.1   10.1.0.1
+
+  Test Global/Child Network net2
+      Should Be Equal   10.1.0.0/24   10.1.0.0/24

--- a/tests/integration/fixtures/templates_list_chunked_dict/test1.robot
+++ b/tests/integration/fixtures/templates_list_chunked_dict/test1.robot
@@ -17,7 +17,7 @@ Test {{ domain.name }} Host {{ host.name }}
 {% for net in domain.objects.networks | default([]) %}
 
 Test {{ domain.name }} Network {{ net.name }}
-    Should Be Equal   {{ net.cidr }}   {{ net.cidr }}
+    Should Be Equal   {{ net.prefix }}   {{ net.prefix }}
 {% endfor %}
 
 {% endif %}

--- a/tests/integration/fixtures/templates_list_chunked_dict/test1.robot
+++ b/tests/integration/fixtures/templates_list_chunked_dict/test1.robot
@@ -1,0 +1,24 @@
+{# iterate_list_chunked fmc.domains name domain_name objects.hosts 2 #}
+*** Settings ***
+Documentation   Test1
+
+*** Test Cases ***
+{% for domain in fmc.domains | default([]) %}
+{% if domain.name == domain_name %}
+
+Test {{ domain.name }}
+
+{% for host in domain.objects.hosts | default([]) %}
+
+Test {{ domain.name }} Host {{ host.name }}
+    Should Be Equal   {{ host.ip }}   {{ host.ip }}
+{% endfor %}
+
+{% for net in domain.objects.networks | default([]) %}
+
+Test {{ domain.name }} Network {{ net.name }}
+    Should Be Equal   {{ net.cidr }}   {{ net.cidr }}
+{% endfor %}
+
+{% endif %}
+{% endfor %}

--- a/tests/integration/test_cli_rendering.py
+++ b/tests/integration/test_cli_rendering.py
@@ -268,6 +268,46 @@ def test_chunked_list_rendering_produces_expected_content(tmp_path: Path) -> Non
     )
 
 
+def test_chunked_list_rendering_produces_expected_content_with_dict_parent(
+    tmp_path: Path,
+) -> None:
+    """Test chunked rendering for a 2-level object_path whose parent is a dict.
+
+    Verifies that when rendering templates with chunked iteration,
+    with a 2-level object_path whose parent is a dict,
+    the CLI creates output files with content split into the expected
+    chunks matching the expected_content.yaml specification.
+    Test uses object_path = "objects.hosts", where "objects" is a dict and "hosts" is a list.
+
+    Args:
+        tmp_path: Pytest fixture providing a temporary directory.
+    """
+    runner = CliRunner()
+    data_path = "tests/integration/fixtures/data_list_chunked_dict/"
+    templates_path = "tests/integration/fixtures/templates_list_chunked_dict/"
+    result = runner.invoke(
+        nac_test.cli.main.app,
+        [
+            "-d",
+            data_path,
+            "-t",
+            templates_path,
+            "-o",
+            str(tmp_path),
+            "--render-only",
+        ],
+    )
+    assert result.exit_code == 0, (
+        f"Chunked dict-parent rendering should succeed, got exit code "
+        f"{result.exit_code}: {result.output}"
+    )
+    robot_results_dir = tmp_path / ROBOT_RESULTS_DIRNAME
+    # Verify files and their content match expected content
+    verify_file_content(
+        Path(templates_path) / "expected_content.yaml", robot_results_dir
+    )
+
+
 def test_merged_data_model_creates_default_filename(tmp_path: Path) -> None:
     """Test that the merged data model is written with the expected filename and content."""
     runner = CliRunner()

--- a/tests/unit/robot/test_robot_writer.py
+++ b/tests/unit/robot/test_robot_writer.py
@@ -12,6 +12,7 @@ Covers:
 """
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 from jinja2 import Environment, FileSystemLoader
@@ -98,3 +99,77 @@ class TestRobotWriterRenderTemplate:
         assert output.exists()
         assert output.parent.is_dir()
         assert output.read_text().strip()  # non-empty content
+
+
+# ---------------------------------------------------------------------------
+# _chunk_nested_objects tests
+# ---------------------------------------------------------------------------
+
+
+class TestChunkNestedObjects:
+    """Tests for RobotWriter._chunk_nested_objects()."""
+
+    def test_simple_object_path_chunks_direct_list(self, writer: RobotWriter) -> None:
+        """A single-level object_path chunks a list that is a direct child."""
+        data = {"hosts": [{"name": f"h{i}"} for i in range(3)]}
+        chunks = writer._chunk_nested_objects(data, "hosts", 2)
+        assert [[h["name"] for h in c["hosts"]] for c in chunks] == [
+            ["h0", "h1"],
+            ["h2"],
+        ]
+
+    def test_dict_nested_object_path_chunks_in_place(self, writer: RobotWriter) -> None:
+        """2-level object_path whose parent is a dict"""
+        domain: dict[str, Any] = {
+            "name": "Global",
+            "objects": {
+                "hosts": [{"name": f"h{i}"} for i in range(5)],
+                "networks": [{"name": "n1"}],
+            },
+        }
+        chunks = writer._chunk_nested_objects(domain, "objects.hosts", 2)
+
+        # 5 hosts at chunk size 2 -> 3 chunks of 2, 2, 1.
+        assert [len(c["objects"]["hosts"]) for c in chunks] == [2, 2, 1]
+        # Hosts are partitioned in order with no loss or overlap.
+        flat = [h["name"] for c in chunks for h in c["objects"]["hosts"]]
+        assert flat == [f"h{i}" for i in range(5)]
+        # Sibling object types are preserved untouched in every chunk.
+        assert all(c["objects"]["networks"] == [{"name": "n1"}] for c in chunks)
+        # The original input is not mutated.
+        assert len(domain["objects"]["hosts"]) == 5
+
+    def test_dict_nested_non_list_child_returns_original(
+        self, writer: RobotWriter
+    ) -> None:
+        """A dict parent whose child is not a list yields the item unchanged."""
+        data = {"objects": {"hosts": "not-a-list"}}
+        assert writer._chunk_nested_objects(data, "objects.hosts", 2) == [data]
+
+    def test_list_of_parents_object_path_still_chunks(
+        self, writer: RobotWriter
+    ) -> None:
+        """2-level object_path whose parent is a list"""
+        data = {
+            "services": [
+                {
+                    "name": "s1",
+                    "endpoints": [{"name": "e1"}, {"name": "e2"}, {"name": "e3"}],
+                },
+                {"name": "s2", "endpoints": [{"name": "e4"}]},
+                {"name": "s3", "endpoints": [{"name": "e5"}]},
+            ]
+        }
+        chunks = writer._chunk_nested_objects(data, "services.endpoints", 2)
+
+        assert len(chunks) == 3
+        assert [p["name"] for p in chunks[0]["services"]] == ["s1"]
+        assert [e["name"] for e in chunks[0]["services"][0]["endpoints"]] == [
+            "e1",
+            "e2",
+        ]
+        assert [p["name"] for p in chunks[1]["services"]] == ["s1", "s2"]
+        assert [e["name"] for e in chunks[1]["services"][0]["endpoints"]] == ["e3"]
+        assert [e["name"] for e in chunks[1]["services"][1]["endpoints"]] == ["e4"]
+        assert [p["name"] for p in chunks[2]["services"]] == ["s3"]
+        assert [e["name"] for e in chunks[2]["services"][0]["endpoints"]] == ["e5"]

--- a/tests/unit/robot/test_robot_writer.py
+++ b/tests/unit/robot/test_robot_writer.py
@@ -109,7 +109,7 @@ class TestRobotWriterRenderTemplate:
 class TestChunkNestedObjects:
     """Tests for RobotWriter._chunk_nested_objects()."""
 
-    def test_simple_object_path_chunks_direct_list(self, writer: RobotWriter) -> None:
+    def test_one_level_object_path_chunks(self, writer: RobotWriter) -> None:
         """A single-level object_path chunks a list that is a direct child."""
         data = {"hosts": [{"name": f"h{i}"} for i in range(3)]}
         chunks = writer._chunk_nested_objects(data, "hosts", 2)
@@ -118,7 +118,7 @@ class TestChunkNestedObjects:
             ["h2"],
         ]
 
-    def test_dict_nested_object_path_chunks_in_place(self, writer: RobotWriter) -> None:
+    def test_nested_object_path_chunks_leaf_under_dict_parent(self, writer: RobotWriter) -> None:
         """2-level object_path whose parent is a dict"""
         domain: dict[str, Any] = {
             "name": "Global",
@@ -146,7 +146,7 @@ class TestChunkNestedObjects:
         data = {"objects": {"hosts": "not-a-list"}}
         assert writer._chunk_nested_objects(data, "objects.hosts", 2) == [data]
 
-    def test_list_of_parents_object_path_still_chunks(
+    def test_nested_object_path_chunks_leaf_under_list_parent(
         self, writer: RobotWriter
     ) -> None:
         """2-level object_path whose parent is a list"""

--- a/tests/unit/robot/test_robot_writer.py
+++ b/tests/unit/robot/test_robot_writer.py
@@ -118,7 +118,9 @@ class TestChunkNestedObjects:
             ["h2"],
         ]
 
-    def test_nested_object_path_chunks_leaf_under_dict_parent(self, writer: RobotWriter) -> None:
+    def test_nested_object_path_chunks_leaf_under_dict_parent(
+        self, writer: RobotWriter
+    ) -> None:
         """2-level object_path whose parent is a dict"""
         domain: dict[str, Any] = {
             "name": "Global",


### PR DESCRIPTION
## Description

Framework allows the following structure to split test into multiple files

{# iterate_list_chunked <YAML_PATH_TO_LIST> <LIST_ITEM_ID> <JINJA_VARIABLE_NAME> <OBJECT_PATH> <CHUNK_SIZE> #}

<OBJECT_PATH> and have parent_key.child_key, however it assumes that parent_key is a list.
This PR allows parent_key to be a dict.

## Closes
- #875 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Technical debt (internal improvements with no user-facing changes)
- [ ] Documentation update
- [ ] Chore (build process, CI, tooling, dependencies)
- [ ] Other (please describe):

## Test Framework Affected

- [ ] PyATS
- [X] Robot Framework
- [ ] Both
- [ ] N/A (not test-framework specific)

## Network as Code (NaC) Architecture Affected

- [ ] ACI (APIC)
- [ ] NDO (Nexus Dashboard Orchestrator)
- [ ] NDFC / VXLAN-EVPN (Nexus Dashboard Fabric Controller)
- [ ] Catalyst SD-WAN (SDWAN Manager / vManage)
- [ ] Catalyst Center (DNA Center)
- [ ] ISE (Identity Services Engine)
- [ ] FMC (Firepower Management Center)
- [ ] Meraki (Cloud-managed)
- [ ] NX-OS (Nexus Direct-to-Device)
- [ ] IOS-XE (Direct-to-Device)
- [ ] IOS-XR (Direct-to-Device)
- [ ] Hyperfabric
- [X] All architectures
- [ ] N/A (architecture-agnostic)

## Platform Tested

> nac-test supports macOS and Linux only

- [X] macOS (version tested: 26.5.1)
- [ ] Linux (distro/version tested: )

## Key Changes

Summarize the main changes in this PR:
- Update RobotWriter._chunk_nested_objects()
- Add tests

## Testing Done

- [X] Unit tests added/updated
- [ ] Integration tests performed
- [ ] Manual testing performed:
  - [ ] PyATS tests executed successfully
  - [X] Robot Framework tests executed successfully
  - [ ] D2D/SSH tests executed successfully (if applicable)
  - [ ] HTML reports generated correctly
- [X] All existing tests pass (`pytest` / `pre-commit run -a`)

### Test Commands Used

```bash
# Commands used to test changes
```

## Checklist

- [X] Code follows project style guidelines (`pre-commit run -a` passes)
- [X] Self-review of code completed
- [X] Code is commented where necessary (especially complex logic)
- [ ] Documentation updated (if applicable)
- [X] No new warnings introduced
- [ ] Changes work on both macOS and Linux
- [ ] CHANGELOG.md updated (if applicable)