### PR TITLE
feat(cli): add --device-tag argument for per-device filtering

### DIFF
--- a/nac_test/cli/main.py
+++ b/nac_test/cli/main.py
@@ -177,6 +177,16 @@ Exclude = Annotated[
 ]
 
 
+DeviceTag = Annotated[
+    str | None,
+    typer.Option(
+        "--device-tag",
+        help="Only test devices whose 'tags' list in the data model contains this value.",
+        envvar="NAC_TEST_DEVICE_TAG",
+    ),
+]
+
+
 RenderOnly = Annotated[
     bool,
     typer.Option(
@@ -302,6 +312,7 @@ def main(
     tests: Tests = None,
     include: Include = None,
     exclude: Exclude = None,
+    device_tag: DeviceTag = None,
     render_only: RenderOnly = False,
     dry_run: DryRun = False,
     processes: Processes = None,
@@ -411,6 +422,7 @@ def main(
         tests_path=tests,
         include_tags=include,
         exclude_tags=exclude,
+        device_tag=device_tag,
         render_only=render_only,
         dry_run=dry_run,
         processes=processes,

--- a/nac_test/combined_orchestrator.py
+++ b/nac_test/combined_orchestrator.py
@@ -80,6 +80,7 @@ class CombinedOrchestrator:
         tests_path: Path | None = None,
         include_tags: list[str] | None = None,
         exclude_tags: list[str] | None = None,
+        device_tag: str | None = None,
         render_only: bool = False,
         dry_run: bool = False,
         max_parallel_devices: int | None = None,
@@ -127,6 +128,7 @@ class CombinedOrchestrator:
         self.tests_path = tests_path
         self.include_tags = include_tags or []
         self.exclude_tags = exclude_tags or []
+        self.device_tag = device_tag
         self.render_only = render_only
         self.dry_run = dry_run
         self.processes = processes
@@ -224,6 +226,7 @@ class CombinedOrchestrator:
                 loglevel=self.loglevel,
                 include_tags=self.include_tags,
                 exclude_tags=self.exclude_tags,
+                device_tag=self.device_tag,
             )
             if self.max_parallel_devices is not None:
                 pyats_orchestrator.max_parallel_devices = self.max_parallel_devices

--- a/nac_test/pyats_core/execution/device/device_executor.py
+++ b/nac_test/pyats_core/execution/device/device_executor.py
@@ -32,6 +32,7 @@ class DeviceExecutor:
         base_output_dir: Path,
         merged_data_path: Path,
         custom_testbed_path: Path | None = None,
+        device_tag: str | None = None,
     ):
         """Initialize device executor.
 
@@ -43,6 +44,7 @@ class DeviceExecutor:
             base_output_dir: Base output directory for test results
             merged_data_path: Path to the merged data model YAML file
             custom_testbed_path: Optional path to custom PyATS testbed YAML
+            device_tag: Only test devices whose 'tags' list contains this value
         """
         self.job_generator = job_generator
         self.subprocess_runner = subprocess_runner
@@ -51,6 +53,7 @@ class DeviceExecutor:
         self.base_output_dir = base_output_dir
         self.merged_data_path = merged_data_path
         self.custom_testbed_path = custom_testbed_path
+        self.device_tag = device_tag
 
     async def run_device_job_with_semaphore(
         self,
@@ -108,17 +111,18 @@ class DeviceExecutor:
                 # Set up environment for this device
                 # Always start with a copy of os.environ to preserve PATH and other variables
                 env = os.environ.copy()
-                env.update(
-                    {
-                        "HOSTNAME": hostname,
-                        "DEVICE_INFO": json.dumps(device),
-                        "MERGED_DATA_MODEL_TEST_VARIABLES_FILEPATH": str(
-                            self.merged_data_path
-                        ),
-                        "NAC_TEST_TYPE": "d2d",
-                        ENV_TEST_DIR: str(self.test_dir),
-                    }
-                )
+                env_updates: dict[str, str] = {
+                    "HOSTNAME": hostname,
+                    "DEVICE_INFO": json.dumps(device),
+                    "MERGED_DATA_MODEL_TEST_VARIABLES_FILEPATH": str(
+                        self.merged_data_path
+                    ),
+                    "NAC_TEST_TYPE": "d2d",
+                    ENV_TEST_DIR: str(self.test_dir),
+                }
+                if self.device_tag:
+                    env_updates["NAC_TEST_DEVICE_TAG"] = self.device_tag
+                env.update(env_updates)
 
                 # Track test status for this device.
                 #

--- a/nac_test/pyats_core/orchestrator.py
+++ b/nac_test/pyats_core/orchestrator.py
@@ -75,6 +75,7 @@ class PyATSOrchestrator:
         loglevel: LogLevel = DEFAULT_LOGLEVEL,
         include_tags: list[str] | None = None,
         exclude_tags: list[str] | None = None,
+        device_tag: str | None = None,
     ):
         """Initialize the PyATS orchestrator.
 
@@ -91,6 +92,7 @@ class PyATSOrchestrator:
             loglevel: Log level for PyATS output filtering
             include_tags: Tag patterns to include (Robot Framework syntax)
             exclude_tags: Tag patterns to exclude (Robot Framework syntax)
+            device_tag: Only test devices whose 'tags' list contains this value
         """
         self.data_paths = data_paths
         # Use absolute() rather than resolve() to preserve symlinks — resolve() would
@@ -112,6 +114,7 @@ class PyATSOrchestrator:
         self.loglevel = loglevel
         self.include_tags = include_tags
         self.exclude_tags = exclude_tags
+        self.device_tag = device_tag
 
         # Track test status by type for combined summary
         self.api_test_status: dict[str, dict[str, Any]] = {}
@@ -278,6 +281,9 @@ class PyATSOrchestrator:
             env["NAC_TEST_TYPE"] = "api"
             # Pass test_dir so plugin can compute relative test names
             env[ENV_TEST_DIR] = str(self.test_dir)
+            # Pass device tag filter to subprocess for per-device scoping
+            if self.device_tag:
+                env["NAC_TEST_DEVICE_TAG"] = self.device_tag
 
             # Execute and return the archive path
             assert self.subprocess_runner is not None  # Should be initialized by now
@@ -393,6 +399,7 @@ class PyATSOrchestrator:
                 self.base_output_dir,
                 self.merged_data_path,
                 self.custom_testbed_path,
+                device_tag=self.device_tag,
             )
 
         # Use a local narrowed variable to satisfy mypy
@@ -659,6 +666,12 @@ class PyATSOrchestrator:
             tasks.append(self._execute_api_tests_standard(api_tests))
 
         if d2d_tests:
+            # Set device tag in environment so the resolver can filter during discovery
+            if self.device_tag:
+                os.environ["NAC_TEST_DEVICE_TAG"] = self.device_tag
+            elif "NAC_TEST_DEVICE_TAG" in os.environ:
+                del os.environ["NAC_TEST_DEVICE_TAG"]
+
             # Get device inventory for D2D tests
             devices = self.device_inventory_discovery.get_device_inventory(d2d_tests)
 

--- a/tests/unit/test_combined_orchestrator_controller.py
+++ b/tests/unit/test_combined_orchestrator_controller.py
@@ -239,6 +239,7 @@ class TestCombinedOrchestratorController:
                     loglevel=DEFAULT_LOGLEVEL,
                     include_tags=[],
                     exclude_tags=[],
+                    device_tag=None,
                 )
 
                 # Verify run_tests was called on the instance
@@ -404,6 +405,7 @@ class TestCombinedOrchestratorController:
                     loglevel=DEFAULT_LOGLEVEL,
                     include_tags=[],
                     exclude_tags=[],
+                    device_tag=None,
                 )
 
                 # Verify run_tests was called on the instance


### PR DESCRIPTION
## Description

Adds a `--device-tag` CLI argument (also settable via `NAC_TEST_DEVICE_TAG` env var) that filters test execution to only devices whose `tags` list in the data model contains the specified value. This enables a single set of test scripts to serve dual purposes — scoped to specific devices (e.g., `--device-tag migration`) or fabric-wide (no flag) — without duplicating test code.

Although SD-WAN is the catalyst for this change and the first architecture where the pattern is implemented (driven by an immediate customer need for post-migration validation), the intent is for each architecture to adopt this mechanism to filter operational tests down to a user-defined subset of devices. The CLI argument and env var plumbing are architecture-agnostic; only the per-architecture base class/resolver needs to read the env var and filter accordingly.

## Related Issue(s)

- Companion PR: https://github.com/netascode/nac-test-pyats-common/pull/39

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Test Framework Affected

- [x] PyATS
- [ ] Robot Framework
- [ ] Both
- [ ] N/A (not test-framework specific)

## Network as Code (NaC) Architecture Affected

- [x] Catalyst SD-WAN (SDWAN Manager / vManage)
- [x] All architectures

SD-WAN is the first implementation. The CLI/orchestrator plumbing is architecture-agnostic — future architectures add filtering by reading `NAC_TEST_DEVICE_TAG` in their resolver or base class.

## Platform Tested

- [x] macOS (version tested: Darwin 25.5.0)

## Key Changes

- **CLI** (`nac_test/cli/main.py`): New `--device-tag` option with `NAC_TEST_DEVICE_TAG` envvar support
- **CombinedOrchestrator** (`nac_test/combined_orchestrator.py`): Accepts and stores `device_tag`, forwards to PyATSOrchestrator
- **PyATSOrchestrator** (`nac_test/pyats_core/orchestrator.py`): Injects `NAC_TEST_DEVICE_TAG` into subprocess env for API tests; sets env var before D2D device discovery
- **DeviceExecutor** (`nac_test/pyats_core/execution/device/device_executor.py`): Injects `NAC_TEST_DEVICE_TAG` into D2D subprocess env

## Testing Done

- [x] Unit tests added/updated
- [x] Integration tests performed
- [x] Manual testing performed:
  - [x] PyATS tests executed successfully
  - [ ] Robot Framework tests executed successfully
  - [ ] D2D/SSH tests executed successfully (if applicable)
  - [ ] HTML reports generated correctly
- [x] All existing tests pass (`pytest` / `pre-commit run -a`)

### Test Commands Used

```bash
# Pre-commit (ruff, mypy, bandit all pass)
pre-commit run -a

# Integration test: no devices tagged → no API calls
nac-test -d ./data -d ./defaults -t ./tests/templates --device-tag migration --pyats -o ./tests/results/sdwan

# Integration test: one device tagged → only that device tested
# (added tags: ["migration"] to one router in data model)
nac-test -d ./data -d ./defaults -t ./tests/templates --device-tag migration --pyats -o ./tests/results/sdwan

# Integration test: no flag → all devices tested (regression-free)
nac-test -d ./data -d ./defaults -t ./tests/templates --pyats -o ./tests/results/sdwan
```

## Checklist

- [x] Code follows project style guidelines (`pre-commit run -a` passes)
- [x] Self-review of code completed
- [x] Code is commented where necessary (especially complex logic)
- [ ] Documentation updated (if applicable)
- [x] No new warnings introduced
- [ ] Changes work on both macOS and Linux
- [ ] CHANGELOG.md updated (if applicable)

## Additional Notes

- The value is threaded via environment variables because pyATS tests run in separate subprocesses — Python objects cannot be passed across the process boundary
- The filtering itself happens in `nac-test-pyats-common` (companion PR #39) — this PR only handles the CLI argument and env var plumbing
- CI usage pattern:
  ```yaml
  # Migration stage (only tagged devices)
  nac-test -d ./data -t ./tests/templates --device-tag migration

  # Fabric-wide operational stage (all devices)
  nac-test -d ./data -t ./tests/templates
  ```
- Test scripts can also declare `groups = ["migration"]` to be excluded from fabric-wide runs via `--exclude migration`, enabling both device-level AND test-level scoping